### PR TITLE
Adding Type & Grade Aggregators to resolvers

### DIFF
--- a/src/db/AreaSchema.ts
+++ b/src/db/AreaSchema.ts
@@ -1,6 +1,6 @@
 import mongoose from 'mongoose'
 // import { v4 as uuidv4 } from 'uuid'
-import { AreaType, IAreaContent, IAreaMetadata } from './AreaTypes.js'
+import { AreaType, IAreaContent, IAreaMetadata, AggregateType, CountByGroupType, PointType } from './AreaTypes.js'
 import { ClimbSchema } from './ClimbSchema.js'
 
 const { Schema, connection, Types } = mongoose
@@ -23,11 +23,29 @@ const ContentSchema = new Schema<IAreaContent>({
   description: { type: Schema.Types.String }
 })
 
+export const CountByGroup = new Schema<CountByGroupType>({
+  count: { type: Number, required: true },
+  label: { type: String, required: true }
+})
+
+export const Point = new Schema<PointType>({
+  lat: { type: Number, required: true },
+  lng: { type: Number, required: true }
+})
+const AggregateSchema = new Schema<AggregateType>({
+  byGrade: [{ type: CountByGroup, required: true }],
+  byType: [{ type: CountByGroup, required: true }],
+  bounds: [{ type: Point, required: true }],
+  density: { type: Number, required: true },
+  totalClimbs: { type: Number }
+})
+
 const AreaSchema = new Schema<AreaType>({
   area_name: { type: String, required: true, index: true },
   climbs: [{ type: ClimbSchema, required: true }],
   children: [{ type: Types.ObjectId, ref: 'areas', required: true }],
   ancestors: [{ type: String, required: true }],
+  aggregate: AggregateSchema,
   metadata: MetadataSchema,
   content: ContentSchema,
   parentHashRef: { type: String, required: true },

--- a/src/db/AreaTypes.ts
+++ b/src/db/AreaTypes.ts
@@ -1,4 +1,5 @@
 import { Types } from 'mongoose'
+
 import { ClimbType } from './ClimbTypes'
 
 export type AreaType = IAreaProps & {
@@ -10,6 +11,7 @@ export interface IAreaProps {
   climbs?: ClimbType[]
   children?: [Types.ObjectId]
   ancestors: string[]
+  aggregate: AggregateType
   content: IAreaContent
   parentHashRef: string
   pathHash: string
@@ -26,4 +28,18 @@ export interface IAreaMetadata {
 }
 export interface IAreaContent {
   description?: string
+}
+
+export interface CountByGroupType {
+  count: number
+  label: string
+}
+export interface PointType { lat: number, lng: number}
+
+export interface AggregateType {
+  byGrade: [CountByGroupType]
+  byType: [CountByGroupType]
+  bounds: [PointType]
+  density: number
+  totalClimbs: number
 }

--- a/src/db/import/LinkParent.ts
+++ b/src/db/import/LinkParent.ts
@@ -3,8 +3,8 @@ import { getAreaModel } from '../AreaSchema.js'
 export const linkAreas = async (collectionName: string): Promise<void> => {
   try {
     const areasModel = getAreaModel(collectionName)
+
     for await (const area of areasModel.find()) {
-      // console.log(area.get("area_name"))
       const pathHash = area.get('pathHash')
 
       // find all areas whose parent = my pathHash (aka subareas)

--- a/src/schema/AreaTypeDef.ts
+++ b/src/schema/AreaTypeDef.ts
@@ -19,6 +19,7 @@ export const typeDef = gql`
     climbs: [Climb]
     children: [Area]
     ancestors: [String]
+    aggregate: AggregateType
     content: AreaContent
     pathHash: String
     pathTokens: [String]
@@ -34,23 +35,50 @@ export const typeDef = gql`
     area_id: String!
   }
 
+  type AggregateType {
+    byGrade: [CountByGroupType]
+    byType: [CountByGroupType]
+    bounds: [Point]
+    density: Float
+    totalClimbs: Int
+  }
+  
+  type Point {
+    lat: Float,
+    lng: Float
+  }
+  
+  
+  type CountByGroupType {
+    count: Int
+    label: String
+  }
+
   type AreaContent {
     description: String
   }
   
   input Sort {
     area_name: Int
+    density: Int
+    totalClimbs: Int
   }
 
   input Filter {
     area_name: AreaFilter
     leaf_status: LeafFilter
     path_tokens: PathFilter
+    density: DensityFilter
+  }
+
+  input DensityFilter  { 
+    density: Float
   }
 
   input PathFilter  { 
-    tokens: [String]!, 
+    tokens: [String]!
     exactMatch: Boolean 
+    size: Int
   }
 
   input AreaFilter {

--- a/src/schema/GraphQLSchema.ts
+++ b/src/schema/GraphQLSchema.ts
@@ -4,6 +4,7 @@ import { typeDef as Climb } from './ClimbTypeDef.js'
 import { typeDef as Area } from './AreaTypeDef.js'
 import { GQLFilter, Sort } from '../types'
 import { md5 } from '../db/import/utils.js'
+import { AreaType, CountByGroupType, PointType } from '../db/AreaTypes.js'
 
 const resolvers = {
   Query: {
@@ -18,7 +19,7 @@ const resolvers = {
     },
     areas: async (
       _,
-      { filter, sort }: { filter?: GQLFilter, sort?: Sort},
+      { filter, sort }: { filter?: GQLFilter, sort?: Sort },
       { dataSources: { areas } }
     ) => {
       const filtered = await areas.findAreasByFilter(filter)
@@ -39,13 +40,61 @@ const resolvers = {
   Climb: {
     // TODO: let's see if we need to create any field resolvers
   },
-
   Area: {
     children: async (parent, _, { dataSources: { areas } }) => {
       if (parent.children.length > 0) {
         return areas.findManyByIds(parent.children)
       }
       return []
+    },
+    aggregate: async (parent, _, { dataSources: { areas } }) => {
+      // get all leafs under this parent
+      const allChildAreas: AreaType[] = await getAllLeafs(areas, parent.pathTokens)
+      const bounds: [PointType, PointType] = [
+        { lat: Number.POSITIVE_INFINITY, lng: Number.POSITIVE_INFINITY },
+        { lat: Number.NEGATIVE_INFINITY, lng: Number.NEGATIVE_INFINITY }]
+      const byGrade = {}
+      const byType = {}
+
+      let totalClimbs = 0
+
+      allChildAreas.forEach(area => {
+        if (area.climbs === undefined) { // shouldn't exist in our set, but handle anyway
+          return
+        }
+
+        if (area.metadata.lat !== null && area.metadata.lng !== null) {
+          updateBounds(area.metadata.lat, area.metadata.lng, bounds)
+        }
+
+        area.climbs.forEach((climb) => {
+          const { yds, type, metadata: { lat, lng } } = climb
+          // Grade
+          const entry: CountByGroupType = byGrade[yds] === undefined ? { label: yds, count: 0 } : byGrade[yds]
+          entry.count = entry.count + 1
+          byGrade[yds] = entry
+          if (lat !== null && lng !== null) {
+            updateBounds(lat, lng, bounds)
+          }
+          for (const t in type) {
+            if (type[t] !== false) {
+              const entry: CountByGroupType = byType[t] !== undefined ? byType[t] : { label: t, count: 0 }
+              byType[t] = Object.assign(entry, { count: entry.count + 1 })
+            }
+          }
+          totalClimbs += 1
+        })
+      })
+
+      const density = getAreaDensity(bounds, totalClimbs)
+
+      return {
+        byGrade: Object.values(byGrade),
+        byType: Object.values(byType),
+        bounds,
+        density,
+        totalClimbs
+      }
     },
     ancestors: async (parent, _, { dataSources: { areas } }) => {
       const ancestors: string[] = []
@@ -56,11 +105,28 @@ const resolvers = {
       }
       const areaAncestors = await areas.findManyByPathHash(ancestors)
       return areaAncestors.map(area => area.metadata.area_id)
-    },
-    id: async (parent, _, __) => {
-      return parent._id.toString()
     }
   }
+}
+
+const getAllLeafs = async (areas, parentTokens): Promise<AreaType[]> => {
+  const childAreasCollection = await areas.findAreasByFilter({ leaf_status: { isLeaf: true }, path_tokens: { tokens: parentTokens, exactMatch: false } })
+  return childAreasCollection.toArray()
+}
+
+const getAreaDensity = (bounds: [PointType, PointType], totalClimbs: number): number => {
+  const areaInKm = (bounds[1].lat - bounds[0].lat) * (bounds[1].lng - bounds[0].lng) * 111 * 111
+  const minArea = areaInKm === 0 ? 5 : areaInKm
+  return totalClimbs / minArea
+}
+
+const updateBounds = (lat: number, lng: number, bound: [PointType, PointType]): void => {
+  // Bottom left of bounding box
+  bound[0].lat = Math.min(bound[0].lat, lat)
+  bound[0].lng = Math.min(bound[0].lng, lng)
+  // Top Right of bounding box
+  bound[1].lat = Math.max(bound[1].lat, lat)
+  bound[1].lng = Math.max(bound[1].lng, lng)
 }
 
 export const schema = makeExecutableSchema({

--- a/src/types.ts
+++ b/src/types.ts
@@ -4,11 +4,22 @@ export enum SortDirection {
   DESC = -1
 }
 
-type Sortable = 'area_name'
+export type Sortable = 'area_name'
 
-export type Sort = Map<Sortable, SortDirection>
+export type Sort = Record<Sortable, SortDirection>
 
 type Filterable = 'area_name' | 'leaf_status' | 'path_tokens'
+
+interface Compare { num: number, comparison: 'lt' | 'gt' | 'eq' }
+
+export interface ComparisonFilterParams {
+  field: 'totalClimbs'
+  comparisons: Compare[]
+}
+
+export interface DensityParams {
+  density: number // 0 = low, 1 = moderate, 2 = medium, 3 = high
+}
 
 export interface AreaFilterParams {
   match: string
@@ -22,7 +33,8 @@ export interface LeafStatusParams {
 export interface PathTokenParams {
   tokens: string[]
   exactMatch: boolean | undefined
+  size: number
 }
 
-type FilterParams = AreaFilterParams | LeafStatusParams | PathTokenParams
+type FilterParams = AreaFilterParams | LeafStatusParams | PathTokenParams | DensityParams
 export type GQLFilter = Record<Filterable, FilterParams>


### PR DESCRIPTION
Mayyybe unwise. I haven't looked at performance at all. 

@vnugent I want to move density / total climbs to be stored in mongo instead derived later. But wanted to see what you thought first. Apparently you cant add filtering/sorting on resolved fields (as far as I could figure out) The parents resolve first, then the children, so you don't get access to the data. 