### PR TITLE
Support minDistance and optional payload in cragsNear query

### DIFF
--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
     "test": "NODE_OPTIONS=--experimental-vm-modules jest",
     "build": "tsc  -p tsconfig.build.json",
     "clean": "tsc -b --clean && rm -rf build/*",
-    "serve": "node build/main.js",
+    "serve": "yarn build && node build/main.js",
     "refresh-db": "./refresh-db.sh",
     "seed-usa": "yarn build && node build/db/import/usa/USADay0Seed.js",
     "init-db": "yarn build && node build/db/utils/jobs/UpdateAllRunner.js",

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,17 +1,18 @@
 import { ApolloServer } from 'apollo-server'
+import { DataSources } from 'apollo-server-core/dist/graphqlOptions'
 import mongoose from 'mongoose'
 import { schema as graphQLSchema } from './schema/GraphQLSchema.js'
 import { connectDB } from './db/index.js'
-import Areas from './model/Areas.js'
+import AreaDataSource from './model/AreaDataSource.js'
 
 // eslint-disable-next-line
 (async function (): Promise<void> {
   const server = new ApolloServer({
     introspection: true,
     schema: graphQLSchema,
-    dataSources: () => {
+    dataSources: (): DataSources<AreaDataSource> => {
       return {
-        areas: new Areas(mongoose.connection.db.collection('areas'))
+        areas: new AreaDataSource(mongoose.connection.db.collection('areas'))
       }
     }
   })

--- a/src/schema/AreaTypeDef.ts
+++ b/src/schema/AreaTypeDef.ts
@@ -5,7 +5,7 @@ export const typeDef = gql`
     area(id: ID, uuid: String): Area
     areas(filter: Filter, sort: Sort): [Area]
     stats: Stats
-    cragsNear(placeId: String, lnglat: Point, maxDistance: Int): [CragsNear]
+    cragsNear(placeId: String, lnglat: Point, minDistance: Int = 0, maxDistance: Int = 48000, includeCrags: Boolean = false): [CragsNear]
   }
 
   "A climbing area, wall or crag"

--- a/src/schema/GraphQLSchema.ts
+++ b/src/schema/GraphQLSchema.ts
@@ -1,10 +1,12 @@
 import { makeExecutableSchema } from '@graphql-tools/schema'
+import { DataSources } from 'apollo-server-core/dist/graphqlOptions'
 
 import { typeDef as Climb } from './ClimbTypeDef.js'
 import { typeDef as Area } from './AreaTypeDef.js'
 import { GQLFilter, Sort } from '../types'
 import { AreaType } from '../db/AreaTypes.js'
 import { ClimbType } from '../db/ClimbTypes.js'
+import AreaDataSource from '../model/AreaDataSource.js'
 
 const resolvers = {
   Query: {
@@ -45,9 +47,15 @@ const resolvers = {
     cragsNear: async (
       node: any,
       args,
-      { dataSources }) => {
-      const { placeId, lnglat, maxDistance } = args
-      return dataSources.areas.getCragsNear(placeId, [lnglat.lng, lnglat.lat], maxDistance > 325000 ? 325000 : maxDistance)
+      { dataSources }: {dataSources: DataSources<AreaDataSource>}) => {
+      const { placeId, lnglat, minDistance, maxDistance, includeCrags } = args
+      const areas = dataSources.areas as AreaDataSource
+      return await areas.getCragsNear(
+        placeId,
+        [lnglat.lng, lnglat.lat],
+        minDistance < 0 ? 0 : minDistance,
+        maxDistance > 325000 ? 325000 : maxDistance,
+        includeCrags)
     }
   },
 


### PR DESCRIPTION
Support new params in `cragsNear` query:
- [x] `minDistance`: can be used together maxDistance to find crags in outer ring, "donut" shape.
- [x] `includeCrags` flag: lighten up the backend/db to include crag data only when we need to show the result.