### PR TITLE
Return climb in uuid format

### DIFF
--- a/src/graphql/media/MediaResolvers.ts
+++ b/src/graphql/media/MediaResolvers.ts
@@ -2,7 +2,7 @@ import { MediaType, RefModelType } from '../../db/MediaTypes.js'
 const MediaResolvers = {
   MediaTagType: {
     mediaUuid: (node: MediaType) => node.mediaUuid.toUUID().toString(),
-    destination: (node: MediaType) => node.destinationId
+    destination: (node: MediaType) => node.destinationId.toUUID().toString()
   },
 
   TagEntryResult: {


### PR DESCRIPTION
I forgot to return internal uuid to friendly uuid format.  Example: 123e4567-e89b-12d3-a456-426614174000
 
This is needed by https://github.com/OpenBeta/open-tacos/issues/339