### PR TITLE
Support French and other grading systems (#111)

### DIFF
--- a/src/db/ClimbSchema.ts
+++ b/src/db/ClimbSchema.ts
@@ -1,7 +1,7 @@
 import mongoose from 'mongoose'
 import muuid from 'uuid-mongodb'
 import { Point } from '@turf/helpers'
-import { ClimbType, IClimbMetadata, IClimbContent, SafetyType } from './ClimbTypes.js'
+import { ClimbType, IClimbMetadata, IClimbContent, IGradeType, SafetyType } from './ClimbTypes.js'
 
 const { Schema } = mongoose
 
@@ -47,6 +47,12 @@ const MetadataSchema = new Schema<IClimbMetadata>({
   }
 }, { _id: false })
 
+const GradeTypeSchema = new Schema<IGradeType>({
+  yds: { type: Schema.Types.String, required: false },
+  french: { type: Schema.Types.String, required: false },
+  font: { type: Schema.Types.String, required: false }
+}, { _id: false })
+
 export const ClimbSchema = new Schema<ClimbType>({
   _id: {
     type: 'object',
@@ -55,6 +61,7 @@ export const ClimbSchema = new Schema<ClimbType>({
   },
   name: { type: Schema.Types.String, required: true, index: true },
   yds: { type: Schema.Types.String, required: true },
+  grade: GradeTypeSchema,
   fa: { type: Schema.Types.String, required: false },
   type: { type: Schema.Types.Mixed },
   safety: {

--- a/src/db/ClimbTypes.ts
+++ b/src/db/ClimbTypes.ts
@@ -21,6 +21,7 @@ export interface IClimbProps {
   name: string
   fa?: string
   yds: string
+  grade: IGradeType
   type: IClimbType
   safety: SafetyType
   _change?: ChangeRecordMetadataType
@@ -33,6 +34,19 @@ export enum SafetyType {
   R = 'R',
   X = 'X',
 }
+
+export enum GradeType {
+  YDS = 'YDS',
+  FRENCH = 'French',
+  FONT = 'Font',
+}
+
+export interface IGradeType {
+  yds?: string
+  french?: string
+  font?: string
+}
+
 export interface IClimbType {
   trad: boolean
   sport: boolean

--- a/src/db/import/ClimbTransformer.ts
+++ b/src/db/import/ClimbTransformer.ts
@@ -1,5 +1,5 @@
 import { geometry, Point } from '@turf/helpers'
-import { ClimbType } from '../ClimbTypes.js'
+import { ClimbType, GradeType } from '../ClimbTypes.js'
 import muuid from 'uuid-mongodb'
 import { v5 as uuidv5, NIL } from 'uuid'
 
@@ -16,6 +16,11 @@ const transformClimbRecord = (row: any): ClimbType => {
     _id: uuid,
     name: route_name,
     yds: grade.YDS,
+    grade: {
+      yds: grade[GradeType.YDS],
+      font: grade[GradeType.FONT],
+      french: grade[GradeType.FRENCH]
+    },
     safety: safety,
     type: type,
     fa: fa,

--- a/src/graphql/ClimbTypeDef.ts
+++ b/src/graphql/ClimbTypeDef.ts
@@ -12,6 +12,7 @@ export const typeDef = gql`
     name: String!
     fa: String!
     yds: String!
+    grade: GradeType!
     type: ClimbType!
     safety: SafetyEnum!
     metadata: ClimbMetadata!
@@ -45,6 +46,12 @@ export const typeDef = gql`
     mixed: Boolean
     aid: Boolean
     tr: Boolean
+  }
+
+  type GradeType {
+    yds: String
+    french: String
+    font: String
   }
 
   enum SafetyEnum {


### PR DESCRIPTION
* Updates the ClimbSchema to support grade systems other than YDS
* Adds French and Font grade systems to a new "grade" key in the schema
* Updates the GQL for the Climb query to handle YDS, French, and Font grade systems

This handles the first two tasks within #111.
> Update the Climb schema to support other systems (we can prioritize the French system for now)
> Update GQL queries

This will not account for the last two tasks. That will be looked into next.
> Migrate frontend to new fields (PR TBD)
> Delete old yds fields from schema and GQL

NOTE: What will need to be updated, but seemed out of scope was the TickSchema. It currently uses its own "grade" key, which is mapped to just a YDS grade atm, from what it looks like.