### PR TITLE
Enable indexes on ticks collection in test

### DIFF
--- a/src/model/__tests__/ticks.ts
+++ b/src/model/__tests__/ticks.ts
@@ -35,7 +35,7 @@ const tickUpdate: TickType = produce(toTest, draft => {
 })
 
 const testImport: TickType[] = [
-  toTest, toTest2
+  toTest, toTest2, tickUpdate
 ]
 
 describe('Ticks', () => {
@@ -116,6 +116,9 @@ describe('Ticks', () => {
 
     const tick2 = await tickModel.findOne({ _id: newTicks[1]._id })
     expect(tick2?._id).toEqual(newTicks[1]._id)
+
+    const tick3 = await tickModel.findOne({ _id: newTicks[2]._id })
+    expect(tick3?._id).toEqual(newTicks[2]._id)
   })
 
   it('should grab all ticks by userId', async () => {

--- a/src/model/__tests__/ticks.ts
+++ b/src/model/__tests__/ticks.ts
@@ -1,5 +1,5 @@
 import mongoose from 'mongoose'
-
+import { produce } from 'immer'
 import TickDataSource from '../TickDataSource.js'
 import { connectDB, getTickModel } from '../../db/index.js'
 import { TickType } from '../../db/TickTypes.js'
@@ -28,20 +28,14 @@ const toTest2: TickType = {
   source: 'MP'
 }
 
-const tickUpdate: TickType = {
-  name: 'Small Dog',
-  notes: 'Not sandbagged',
-  climbId: 'c76d2083-6b8f-524a-8fb8-76e1dc79833f',
-  userId: 'abc123',
-  style: 'Lead',
-  attemptType: 'Fell/Hung',
-  dateClimbed: '12/12/12',
-  grade: '5.7',
-  source: 'OB'
-}
+const tickUpdate: TickType = produce(toTest, draft => {
+  draft.notes = 'Not sandbagged'
+  draft.attemptType = 'Fell/Hung'
+  draft.source = 'OB'
+})
 
 const testImport: TickType[] = [
-  toTest, toTest2, tickUpdate
+  toTest, toTest2
 ]
 
 describe('Ticks', () => {
@@ -51,7 +45,6 @@ describe('Ticks', () => {
   beforeAll(async () => {
     console.log('#BeforeAll Ticks')
     await connectDB()
-
     try {
       await getTickModel().collection.drop()
     } catch (e) {
@@ -67,6 +60,7 @@ describe('Ticks', () => {
 
   afterEach(async () => {
     await getTickModel().collection.drop()
+    await tickModel.ensureIndexes()
   })
 
   // test adding tick
@@ -112,17 +106,16 @@ describe('Ticks', () => {
     const newTicks = await ticks.importTicks(testImport)
 
     if (newTicks == null) {
-      fail('Should add three new ticks')
+      fail(`Should add ${testImport.length} new ticks`)
     }
+
+    expect(newTicks?.length).toEqual(testImport.length)
 
     const tick1 = await tickModel.findOne({ _id: newTicks[0]._id })
     expect(tick1?._id).toEqual(newTicks[0]._id)
 
     const tick2 = await tickModel.findOne({ _id: newTicks[1]._id })
     expect(tick2?._id).toEqual(newTicks[1]._id)
-
-    const tick3 = await tickModel.findOne({ _id: newTicks[2]._id })
-    expect(tick3?._id).toEqual(newTicks[2]._id)
   })
 
   it('should grab all ticks by userId', async () => {
@@ -175,5 +168,25 @@ describe('Ticks', () => {
     const newTick = await tickModel.findOne({ _id: OBTick._id })
     expect(newTick?._id).toEqual(OBTick._id)
     expect(newTick?.notes).toEqual('Not sandbagged')
+  })
+
+  it('should reject duplicate ticks', async () => {
+    const tick1: TickType = {
+      name: 'Small Dog',
+      notes: 'Not sandbagged',
+      climbId: 'c76d2083-6b8f-524a-8fb8-76e1dc79833f',
+      userId: 'user123',
+      style: 'Lead',
+      attemptType: 'Fell/Hung',
+      dateClimbed: '12/12/12',
+      grade: '5.7',
+      source: 'OB'
+    }
+
+    await ticks.addTick(tick1)
+
+    await expect(
+      ticks.addTick(tick1)
+    ).rejects.toThrow()
   })
 })


### PR DESCRIPTION
@Downster I enabled indexes in tests and some of them are failing due to unique constraints.  Should we include 'source' in the index?