### PR TITLE
Add grade context to area and climb schemas

### DIFF
--- a/src/db/AreaSchema.ts
+++ b/src/db/AreaSchema.ts
@@ -4,6 +4,7 @@ import muuid from 'uuid-mongodb'
 import { AreaType, IAreaContent, IAreaMetadata, AggregateType, CountByGroupType, CountByDisciplineType, CountByGradeBandType, DisciplineStatsType, OperationType } from './AreaTypes.js'
 import { PointSchema } from './ClimbSchema.js'
 import { ChangeRecordMetadataType } from './ChangeLogType.js'
+import { GradeContexts } from '../grade-utils.js'
 
 const { Schema, connection } = mongoose
 
@@ -53,6 +54,7 @@ export const CountByGroup = new Schema<CountByGroupType>({
 }, { _id: false })
 
 export const CountByGradeBandSchema = new Schema<CountByGradeBandType>({
+  unknown: { type: Number, required: true },
   beginner: { type: Number, required: true },
   intermediate: { type: Number, required: true },
   advance: { type: Number, required: true },
@@ -71,6 +73,8 @@ export const CountByDisciplineSchema = new Schema<CountByDisciplineType>({
   sport: { type: DisciplineStatsSchema, required: false },
   boulder: { type: DisciplineStatsSchema, required: false },
   alpine: { type: DisciplineStatsSchema, required: false },
+  snow: { type: DisciplineStatsSchema, required: false },
+  ice: { type: DisciplineStatsSchema, required: false },
   mixed: { type: DisciplineStatsSchema, required: false },
   aid: { type: DisciplineStatsSchema, required: false },
   tr: { type: DisciplineStatsSchema, required: false }
@@ -93,6 +97,7 @@ export const AreaSchema = new Schema<AreaType>({
   children: [{ type: Schema.Types.ObjectId, ref: 'areas', required: false }],
   ancestors: { type: String, required: true, index: true },
   pathTokens: [{ type: String, required: true, index: true }],
+  gradeContext: { type: String, enum: Object.values(GradeContexts), required: true },
   aggregate: AggregateSchema,
   metadata: MetadataSchema,
   content: ContentSchema,

--- a/src/db/AreaTypes.ts
+++ b/src/db/AreaTypes.ts
@@ -17,6 +17,7 @@ export interface IAreaProps {
   children: mongose.Types.ObjectId[]
   ancestors: string
   pathTokens: string[]
+  gradeContext: string
   aggregate?: AggregateType
   content: IAreaContent
   density: number
@@ -61,6 +62,8 @@ export interface CountByDisciplineType {
   sport?: DisciplineStatsType
   boulder?: DisciplineStatsType
   alpine?: DisciplineStatsType
+  snow?: DisciplineStatsType
+  ice?: DisciplineStatsType
   mixed?: DisciplineStatsType
   aid?: DisciplineStatsType
   tr?: DisciplineStatsType
@@ -72,6 +75,7 @@ export interface DisciplineStatsType {
 }
 
 export interface CountByGradeBandType {
+  unknown: number
   beginner: number
   intermediate: number
   advance: number

--- a/src/db/ClimbSchema.ts
+++ b/src/db/ClimbSchema.ts
@@ -2,6 +2,7 @@ import mongoose from 'mongoose'
 import muuid from 'uuid-mongodb'
 import { Point } from '@turf/helpers'
 import { ClimbType, IClimbMetadata, IClimbContent, IGradeType, SafetyType } from './ClimbTypes.js'
+import { GradeContexts } from '../grade-utils.js'
 
 const { Schema } = mongoose
 
@@ -61,7 +62,8 @@ export const ClimbSchema = new Schema<ClimbType>({
   },
   name: { type: Schema.Types.String, required: true, index: true },
   yds: { type: Schema.Types.String, required: true },
-  grade: GradeTypeSchema,
+  grades: GradeTypeSchema,
+  gradeContext: { type: String, enum: Object.values(GradeContexts), required: false },
   fa: { type: Schema.Types.String, required: false },
   type: { type: Schema.Types.Mixed },
   safety: {

--- a/src/db/ClimbTypes.ts
+++ b/src/db/ClimbTypes.ts
@@ -2,7 +2,7 @@ import { MUUID } from 'uuid-mongodb'
 import { Point } from '@turf/helpers'
 import type { WithId, Document } from 'mongodb'
 import { ChangeRecordMetadataType } from './ChangeLogType'
-import { GradeContexts } from "../grade-utils"
+import { GradeContexts } from '../grade-utils'
 
 // For search climb by id queries
 // Additional fields allow client to build breadcrumbs
@@ -38,9 +38,9 @@ export enum SafetyType {
 }
 
 export interface IGradeType {
-	yds?: string
-	french?: string
-	font?: string
+  yds?: string
+  french?: string
+  font?: string
 }
 
 export interface IClimbType {

--- a/src/db/ClimbTypes.ts
+++ b/src/db/ClimbTypes.ts
@@ -2,6 +2,7 @@ import { MUUID } from 'uuid-mongodb'
 import { Point } from '@turf/helpers'
 import type { WithId, Document } from 'mongodb'
 import { ChangeRecordMetadataType } from './ChangeLogType'
+import { GradeContexts } from "../grade-utils"
 
 // For search climb by id queries
 // Additional fields allow client to build breadcrumbs
@@ -21,7 +22,8 @@ export interface IClimbProps {
   name: string
   fa?: string
   yds: string
-  grade: IGradeType
+  grades: IGradeType
+  gradeContext?: GradeContexts
   type: IClimbType
   safety: SafetyType
   _change?: ChangeRecordMetadataType
@@ -35,16 +37,10 @@ export enum SafetyType {
   X = 'X',
 }
 
-export enum GradeType {
-  YDS = 'YDS',
-  FRENCH = 'French',
-  FONT = 'Font',
-}
-
 export interface IGradeType {
-  yds?: string
-  french?: string
-  font?: string
+	yds?: string
+	french?: string
+	font?: string
 }
 
 export interface IClimbType {
@@ -52,6 +48,8 @@ export interface IClimbType {
   sport: boolean
   boulder: boolean
   alpine: boolean
+  snow: boolean
+  ice: boolean
   mixed: boolean
   aid: boolean
   tr: boolean
@@ -71,6 +69,7 @@ export interface IClimbContent {
 }
 
 export enum GradeBand {
+  UNKNOWN = 'unknown',
   BEGINNER = 'beginner',
   INTERMEDIATE = 'intermediate',
   ADVANCE = 'advance',

--- a/src/db/export/Typesense/Utils.ts
+++ b/src/db/export/Typesense/Utils.ts
@@ -7,6 +7,8 @@ export interface IFlatClimbTypes {
   typeBouldering: boolean
   typeMixed: boolean
   typeAlpine: boolean
+  typeSnow: boolean
+  typeIce: boolean
   typeAid: boolean
 }
 
@@ -18,6 +20,8 @@ export const flattenDisciplines = (type: IClimbType): IFlatClimbTypes => {
     typeBouldering: type?.boulder ?? false,
     typeMixed: type?.mixed ?? false,
     typeAlpine: type?.alpine ?? false,
+    typeSnow: type?.snow ?? false,
+    typeIce: type?.ice ?? false,
     typeAid: type?.aid ?? false
   }
 }

--- a/src/db/import/ClimbTransformer.ts
+++ b/src/db/import/ClimbTransformer.ts
@@ -1,11 +1,11 @@
 import { geometry, Point } from '@turf/helpers'
-import { ClimbType, GradeType } from '../ClimbTypes.js'
+import { ClimbType } from '../ClimbTypes.js'
 import muuid from 'uuid-mongodb'
 import { v5 as uuidv5, NIL } from 'uuid'
 
 const transformClimbRecord = (row: any): ClimbType => {
   /* eslint-disable-next-line */
-  const { route_name, grade, safety, type, fa, metadata, description, protection, location } = row
+  const { route_name, grade, gradeContext, safety, type, fa, metadata, description, protection, location } = row
   /* eslint-disable-next-line */
   const { parent_lnglat, left_right_seq, mp_route_id, mp_sector_id } = metadata
 
@@ -16,11 +16,12 @@ const transformClimbRecord = (row: any): ClimbType => {
     _id: uuid,
     name: route_name,
     yds: grade.YDS,
-    grade: {
-      yds: grade[GradeType.YDS],
-      font: grade[GradeType.FONT],
-      french: grade[GradeType.FRENCH]
+    grades: {
+      yds: grade.YDS,
+      font: grade.Font,
+      french: grade.French
     },
+    gradeContext: gradeContext,
     safety: safety,
     type: type,
     fa: fa,

--- a/src/db/import/usa/AreaTransformer.ts
+++ b/src/db/import/usa/AreaTransformer.ts
@@ -91,10 +91,12 @@ export const makeDBArea = (node: AreaNode): AreaType => {
     ancestors: uuidArrayToString(node.getAncestors()),
     climbs: [],
     pathTokens: node.getPathTokens(),
+    gradeContext: node.getGradeContext(),
     aggregate: {
       byGrade: [],
       byDiscipline: {},
       byGradeBand: {
+        unknown: 0,
         beginner: 0,
         intermediate: 0,
         advance: 0,

--- a/src/db/import/usa/AreaTree.ts
+++ b/src/db/import/usa/AreaTree.ts
@@ -12,18 +12,18 @@ export class Tree {
   subRoot: AreaNode
   map = new Map<string, AreaNode>()
 
-  constructor(root?: AreaNode) {
+  constructor (root?: AreaNode) {
     this.root = root
   }
 
-  prefixRoot(key: string): string {
+  prefixRoot (key: string): string {
     if (this.root === undefined) {
       return key
     }
     return `${this.root.key}|${key}`
   }
 
-  private insert(
+  private insert (
     key: string,
     isSubRoot: boolean,
     isLeaf: boolean = false,
@@ -49,7 +49,7 @@ export class Tree {
     return this
   }
 
-  insertMany(path: string, jsonLine: any = undefined): Tree {
+  insertMany (path: string, jsonLine: any = undefined): Tree {
     const tokens: string[] = path.split('|')
     tokens.reduce<string>((acc, curr, index) => {
       if (acc.length === 0) {
@@ -65,17 +65,17 @@ export class Tree {
     return this
   }
 
-  getParent(key: string): AreaNode | undefined {
+  getParent (key: string): AreaNode | undefined {
     const parentPath = key.substring(0, key.lastIndexOf('|'))
     const parent = this.atPath(parentPath)
     return parent
   }
 
-  atPath(path: string): AreaNode | undefined {
+  atPath (path: string): AreaNode | undefined {
     return this.map.get(path)
   }
 
-  getAncestors(node: AreaNode): MUUID[] {
+  getAncestors (node: AreaNode): MUUID[] {
     if (this.root === undefined) {
       // Country root shouldn't have an ancestor so return itself
       return [node.uuid]
@@ -113,11 +113,11 @@ export class Tree {
       // - we pass countryName when calling from addCountry() API
       return countryName != null ? [countryName] : tokens
     }
-      // use countryName if exists
-      tokens.unshift(this.root?.countryName ?? this.root.key)
-      return tokens
+    // use countryName if exists
+    tokens.unshift(this.root?.countryName ?? this.root.key)
+    return tokens
   }
-  
+
   /**
    *
    * @param node
@@ -125,16 +125,14 @@ export class Tree {
    * Inherits from parent tree if current tree does not have one
    * Country root is the highest default grade context
    */
-  getGradeContext(node: AreaNode): string {
+  getGradeContext (node: AreaNode): string {
     const countriesDefaultGradeContext = getCountriesDefaultGradeContext()
-    const USGradeContext = countriesDefaultGradeContext['US']
+    const USGradeContext = countriesDefaultGradeContext.US
     const { key, jsonLine } = node
     // country level, return key
-    if (this.root === undefined)
-      return countriesDefaultGradeContext[key] ?? USGradeContext
+    if (this.root === undefined) { return countriesDefaultGradeContext[key] ?? USGradeContext }
     // imported grade context for current area
-    if (jsonLine !== undefined && jsonLine.gradeContext !== undefined)
-      return jsonLine.gradeContext ?? USGradeContext
+    if (jsonLine?.gradeContext !== undefined) { return jsonLine.gradeContext ?? USGradeContext }
     // check grade context for parent area
     const parent = this.getParent(key)
     if (parent !== undefined) return parent.getGradeContext()
@@ -166,7 +164,7 @@ export class AreaNode {
   }
 
   // create a ref to parent for upward traversal
-  setParent(parent: AreaNode | undefined): AreaNode {
+  setParent (parent: AreaNode | undefined): AreaNode {
     if (parent !== undefined) {
       const { _id } = parent
       this.parentRef = _id
@@ -175,7 +173,7 @@ export class AreaNode {
   }
 
   // add a child node to this node
-  linkChild(child: AreaNode): AreaNode {
+  linkChild (child: AreaNode): AreaNode {
     const { _id } = child
     this.children.add(_id)
     return this
@@ -184,7 +182,7 @@ export class AreaNode {
   /**
    * Return an array of ancestor refs of this node (inclusive)
    */
-  getAncestors(): MUUID[] {
+  getAncestors (): MUUID[] {
     const a = this.treeRef.getAncestors(this)
     return a
   }
@@ -192,7 +190,7 @@ export class AreaNode {
   /**
    * Return an array of ancestor area name of this node (inclusive)
    */
-  getPathTokens(): string[] {
+  getPathTokens (): string[] {
     return this.treeRef.getPathTokens(this)
   }
 
@@ -200,7 +198,7 @@ export class AreaNode {
    * Return the grade context for node
    * Inherits from parent node if current node does not have one
    */
-  getGradeContext(): string {
+  getGradeContext (): string {
     return this.treeRef.getGradeContext(this)
   }
 }

--- a/src/db/utils/Aggregate.ts
+++ b/src/db/utils/Aggregate.ts
@@ -1,7 +1,7 @@
 import _ from 'underscore'
 import { CountByGroupType, CountByDisciplineType, AggregateType, DisciplineStatsType, CountByGradeBandType } from '../AreaTypes.js'
-import { getBand } from '../../grade-utils.js'
-import { ClimbType } from '../ClimbTypes.js'
+import { getBand, gradeContextToGradeScales, GradeScales } from '../../grade-utils.js'
+import { ClimbType, GradeBand } from '../ClimbTypes.js'
 
 export const mergeAggregates = (lhs: AggregateType, rhs: AggregateType): AggregateType => {
   return {
@@ -42,9 +42,10 @@ export const mergeDisciplines =
   }
 
 const mergeBands = (lhs: CountByGradeBandType, rhs: CountByGradeBandType): CountByGradeBandType => {
-  const _l = lhs === undefined ? { ...INIT_GRANDEBAND } : lhs
-  const _r = rhs === undefined ? { ...INIT_GRANDEBAND } : rhs
+  const _l = lhs === undefined ? { ...INIT_GRADEBAND } : lhs
+  const _r = rhs === undefined ? { ...INIT_GRADEBAND } : rhs
   return {
+    unknown: _l.unknown + _r.unknown,
     beginner: _l.beginner + _r.beginner,
     intermediate: _l.intermediate + _r.intermediate,
     advance: _l.advance + _r.advance,
@@ -56,14 +57,25 @@ export const aggregateCragStats = (crag: any): AggregateType => {
   const byGrade: Record<string, number> | {} = {}
   const disciplines: CountByDisciplineType = {}
 
+  // Assumption: all climbs use the crag's grade context
+  const cragGradeScales = gradeContextToGradeScales[crag.gradeContext]
   const climbs = crag.climbs as ClimbType[]
   climbs.forEach((climb: unknown) => {
-    const { yds, type } = (climb as ClimbType)
-
+    const { grades, type = {}, name } = (climb as ClimbType)
     // Grade
-    const entry: CountByGroupType = typeof byGrade[yds] === 'undefined' ? { label: yds, count: 0 } : byGrade[yds]
-    entry.count = entry.count + 1
-    byGrade[yds] = entry
+    // Assumption: all types provided from a climb use the same grade scale
+    const cragGradeType = Object.keys(type).find(t => type[t] === true && cragGradeScales[t] !== undefined)
+    if (cragGradeType !== undefined) {
+        const gradeScale: GradeScales = cragGradeScales[cragGradeType]
+        // Assumption: the climb has the specified grade scale in data.
+        const grade = grades[gradeScale]
+        if (grade === undefined) {
+          console.warn(`Climb: ${name} does not have a corresponding grade with expected grade scale: ${gradeScale}`)
+        }
+        const entry: CountByGroupType = typeof byGrade[grade as string] === 'undefined' ? { label: grade, count: 0 } : byGrade[grade as string]
+        entry.count = entry.count + 1
+        byGrade[grade as string] = entry
+    }
 
     // Disciplines
     for (const t in type) {
@@ -79,14 +91,33 @@ export const aggregateCragStats = (crag: any): AggregateType => {
   })
 
   for (const d in disciplines) {
+    // discipline is grade type
     const climbsByDisciplines = climbs.filter(c => c?.type?.[d] ?? false)
-    const _byGradeBand: Record<string, number> = _.countBy(climbsByDisciplines, x => getBand(x.yds))
+    // TODO: Update to use grade scale per type
+    const gradeScale: GradeScales = cragGradeScales[d]
+    const _byGradeBand: Record<string, number> = _.countBy(climbsByDisciplines, climb => {
+      const grade = climb.grades[gradeScale]
+      if (grade === 'undefined') {
+        console.warn(`Climb: ${climb.name} does not have a corresponding grade with expected grade scale: ${gradeScale}`)
+      }
+      return getBand(grade as string, d, crag.gradeContext)
+    })
 
-    disciplines[d].bands = { ...INIT_GRANDEBAND, ..._byGradeBand }
+    disciplines[d].bands = { ...INIT_GRADEBAND, ..._byGradeBand }
   }
 
-  const _byGradBand: Record<string, number> = _.countBy(climbs, (x) => getBand(x.yds))
-  const z = { ...INIT_GRANDEBAND, ..._byGradBand }
+  const _byGradeBand: Record<string, number> = _.countBy(climbs, (climb: ClimbType) => {
+    const { grades, type = {}, name } = (climb as ClimbType)
+    // Assumption: all types provided from a climb use the same grade scale
+    const cragGradeType = Object.keys(type).find(t => type[t] === true && cragGradeScales[t] !== undefined)
+    const gradeScale: GradeScales = cragGradeScales[cragGradeType]
+    const grade = grades[gradeScale]
+    if (grade === undefined || cragGradeType === undefined) {
+      console.warn(`Climb: ${name} does not have a corresponding grade or type with expected grade scale: ${gradeScale}`)
+      return GradeBand.UNKNOWN
+    }
+    return getBand(grade as string, cragGradeType, crag.gradeContext)})
+  const z = { ...INIT_GRADEBAND, ..._byGradeBand }
   return {
     byGrade: Object.values(byGrade) as [CountByGroupType] | [],
     byDiscipline: disciplines,
@@ -94,7 +125,8 @@ export const aggregateCragStats = (crag: any): AggregateType => {
   }
 }
 
-const INIT_GRANDEBAND: CountByGradeBandType = {
+const INIT_GRADEBAND: CountByGradeBandType = {
+  unknown: 0,
   beginner: 0,
   intermediate: 0,
   advance: 0,
@@ -103,5 +135,5 @@ const INIT_GRANDEBAND: CountByGradeBandType = {
 
 const INIT_DISCIPLINE_STATS: DisciplineStatsType = {
   total: 0,
-  bands: { ...INIT_GRANDEBAND }
+  bands: { ...INIT_GRADEBAND }
 }

--- a/src/db/utils/Aggregate.ts
+++ b/src/db/utils/Aggregate.ts
@@ -66,15 +66,15 @@ export const aggregateCragStats = (crag: any): AggregateType => {
     // Assumption: all types provided from a climb use the same grade scale
     const cragGradeType = Object.keys(type).find(t => type[t] === true && cragGradeScales[t] !== undefined)
     if (cragGradeType !== undefined) {
-        const gradeScale: GradeScales = cragGradeScales[cragGradeType]
-        // Assumption: the climb has the specified grade scale in data.
-        const grade = grades[gradeScale]
-        if (grade === undefined) {
-          console.warn(`Climb: ${name} does not have a corresponding grade with expected grade scale: ${gradeScale}`)
-        }
-        const entry: CountByGroupType = typeof byGrade[grade as string] === 'undefined' ? { label: grade, count: 0 } : byGrade[grade as string]
-        entry.count = entry.count + 1
-        byGrade[grade as string] = entry
+      const gradeScale: GradeScales = cragGradeScales[cragGradeType]
+      // Assumption: the climb has the specified grade scale in data.
+      const grade = grades[gradeScale]
+      if (grade === undefined) {
+        console.warn(`Climb: ${name} does not have a corresponding grade with expected grade scale: ${gradeScale}`)
+      }
+      const entry: CountByGroupType = typeof byGrade[grade as string] === 'undefined' ? { label: grade, count: 0 } : byGrade[grade as string]
+      entry.count = entry.count + 1
+      byGrade[grade as string] = entry
     }
 
     // Disciplines
@@ -107,7 +107,7 @@ export const aggregateCragStats = (crag: any): AggregateType => {
   }
 
   const _byGradeBand: Record<string, number> = _.countBy(climbs, (climb: ClimbType) => {
-    const { grades, type = {}, name } = (climb as ClimbType)
+    const { grades, type = {}, name } = (climb)
     // Assumption: all types provided from a climb use the same grade scale
     const cragGradeType = Object.keys(type).find(t => type[t] === true && cragGradeScales[t] !== undefined)
     const gradeScale: GradeScales = cragGradeScales[cragGradeType]
@@ -116,7 +116,8 @@ export const aggregateCragStats = (crag: any): AggregateType => {
       console.warn(`Climb: ${name} does not have a corresponding grade or type with expected grade scale: ${gradeScale}`)
       return GradeBand.UNKNOWN
     }
-    return getBand(grade as string, cragGradeType, crag.gradeContext)})
+    return getBand(grade, cragGradeType, crag.gradeContext)
+  })
   const z = { ...INIT_GRADEBAND, ..._byGradeBand }
   return {
     byGrade: Object.values(byGrade) as [CountByGroupType] | [],

--- a/src/db/utils/__tests__/Aggregate.test.ts
+++ b/src/db/utils/__tests__/Aggregate.test.ts
@@ -1,11 +1,13 @@
-import { merge } from '../Aggregate.js'
+import { aggregateCragStats, merge } from '../Aggregate.js'
 
 describe('Aggregate merge', () => {
   it('should merge 2 objects', () => {
-    const lhs = [{
-      label: '5.6',
-      count: 1
-    }]
+    const lhs = [
+      {
+        label: '5.6',
+        count: 1
+      }
+    ]
 
     const rhs = [
       {
@@ -30,6 +32,88 @@ describe('Aggregate merge', () => {
         count: 5
       }
     ])
-  }
-  )
+  })
+})
+
+describe('Aggregate Crag Stats', () => {
+  it('Provides crag stat aggregates in US grade context', () => {
+    const crag = {
+      gradeContext: 'US',
+      climbs: [
+        {
+          yds: '5.9',
+          grades: {
+            yds: '5.9',
+            french: '5c'
+          },
+          type: {
+            trad: true,
+            tr: true
+          }
+        },
+        {
+          yds: '5.12b',
+          grades: {
+            yds: '5.12b',
+            french: '7b'
+          },
+          type: {
+            sport: true,
+            tr: true
+          }
+        },
+        {
+          yds: '5.8',
+          grades: {
+            yds: '5.8',
+            french: '5b'
+          },
+          type: {
+            trad: true
+          }
+        },
+        {
+          yds: '5.9',
+          grades: {
+            yds: '5.9',
+            french: '5c'
+          },
+          type: {
+            trad: true,
+            tr: true
+          }
+        }
+      ],
+      totalClimbs: 4
+    }
+    const expectedStats = {
+      byDiscipline: {
+        sport: { bands: { advance: 1, beginner: 0, expert: 0, intermediate: 0, unknown: 0 }, total: 1 },
+        tr: { bands: { advance: 1, beginner: 0, expert: 0, intermediate: 2, unknown: 0 }, total: 3 },
+        trad: { bands: { advance: 0, beginner: 1, expert: 0, intermediate: 2, unknown: 0 }, total: 3 }
+      },
+      byGrade: [
+        { count: 2, label: '5.9' },
+        { count: 1, label: '5.12b' },
+        { count: 1, label: '5.8' }
+      ],
+      byGradeBand: { advance: 1, beginner: 1, expert: 0, intermediate: 2, unknown: 0 }
+    }
+    expect(aggregateCragStats(crag)).toEqual(expectedStats)
+  })
+  it.todo('Provides crag stat aggregates in FR grade context')
+  it('Provides defaults for no climbs in crag', () => {
+    const crag = {
+      gradeContext: 'US',
+      climbs: [],
+      totalClimbs: 0
+    }
+    const expectedStats = {
+      byDiscipline: {},
+      byGrade: [],
+      byGradeBand: { advance: 0, beginner: 0, expert: 0, intermediate: 0, unknown: 0 }
+    }
+    expect(aggregateCragStats(crag)).toEqual(expectedStats)
+  })
+
 })

--- a/src/db/utils/__tests__/Aggregate.test.ts
+++ b/src/db/utils/__tests__/Aggregate.test.ts
@@ -115,5 +115,4 @@ describe('Aggregate Crag Stats', () => {
     }
     expect(aggregateCragStats(crag)).toEqual(expectedStats)
   })
-
 })

--- a/src/db/utils/jobs/AreaUpdater.ts
+++ b/src/db/utils/jobs/AreaUpdater.ts
@@ -88,6 +88,7 @@ const leafReducer = (node: AreaType): ResultType => {
       byGrade: [],
       byDiscipline: {},
       byGradeBand: {
+        unknown: 0,
         beginner: 0,
         intermediate: 0,
         advance: 0,
@@ -139,6 +140,7 @@ const nodesReducer = async (result: ResultType[], parent: AreaMongoType): Promis
       byGrade: [],
       byDiscipline: {},
       byGradeBand: {
+        unknown: 0,
         beginner: 0,
         intermediate: 0,
         advance: 0,

--- a/src/grade-utils.ts
+++ b/src/grade-utils.ts
@@ -1,24 +1,56 @@
-import { getScoreForSort, isVScale, GradeScales } from '@openbeta/sandbag'
+import isoCountries from 'i18n-iso-countries'
+import { getScoreForSort, GradeScales as sbGradeScales } from '@openbeta/sandbag'
 import { GradeBand } from './db/ClimbTypes.js'
+
+export enum GradeContexts {
+  ALSK = 'ALSK',
+  AU = 'AU',
+  BRZ = 'BRZ',
+  FIN = 'FIN',
+  FR = 'FR',
+  HK = 'HK',
+  NWG = 'NWG',
+  POL = 'POL',
+  SA = 'SA',
+  SWE = 'SWE',
+  SX = 'SX',
+  UIAA = 'UIAA',
+  UK = 'UK',
+  US = 'US'
+}
+
+export enum GradeScales {
+  YDS = 'yds',
+  FRENCH = 'french',
+  FONT = 'font',
+  // VSCALE = 'vscale' currently part of YDS grade scale
+}
 
 /**
  * Convert grade to band
- * @param grade yds or v scale
- * @param scale GradeScales.VScale | GradeScales.Yds
+ * @param grade grade of a grade scale
+ * @param discipline type of climb
+ * @param gradeContext grade context to determine grade scale
  * @returns GradeBand
  */
-export const getBand = (grade: string): GradeBand => {
-  const isV = isVScale(grade)
-
-  if (isV) {
-    const score = getScoreForSort(grade, GradeScales.VScale)
+export const getBand = (grade: string, discipline: string | undefined, gradeContext: GradeContexts): GradeBand => {
+  // TODO: Merge GradeScale variable with @openbeta/sandbag GradeScale variable
+  let boulderScale = sbGradeScales.VScale
+  let routeScale = sbGradeScales.Yds 
+  if (gradeContext === GradeContexts.FR) {
+    boulderScale = sbGradeScales.Font
+    routeScale = sbGradeScales.French
+  }
+  if (discipline === "boulder") {
+    const score = getScoreForSort(grade, boulderScale)
     return vScoreToBand(score)
   }
-  const score = getScoreForSort(grade, GradeScales.Yds)
-  return ysdScoreToBand(score)
+  const score = getScoreForSort(grade, routeScale)
+  return ydsScoreToBand(score)
 }
 
-const ysdScoreToBand = (score: number): GradeBand =>
+// TODO: Move score to band logic to @openbeta/sandbag
+const ydsScoreToBand = (score: number): GradeBand =>
   score < 54
     ? GradeBand.BEGINNER
     : score < 67.5
@@ -35,3 +67,125 @@ const vScoreToBand = (score: number): GradeBand =>
       : score < 72 // v3 - v6
         ? GradeBand.ADVANCE
         : GradeBand.EXPERT
+
+/**
+ * A conversion from grade context to corresponding grade type / scale
+ */
+export const gradeContextToGradeScales = {
+  [GradeContexts.US]: {
+    trad: GradeScales.YDS,
+    sport: GradeScales.YDS,
+    boulder: GradeScales.YDS, 
+    tr: GradeScales.YDS,
+    alpine: GradeScales.YDS,
+    mixed: GradeScales.YDS,
+    aid: GradeScales.YDS,
+    snow: GradeScales.YDS, // is this the same as alpine?
+    ice: GradeScales.YDS // is this the same as alpine?
+  },
+  [GradeContexts.FR]: {
+    trad: GradeScales.FRENCH,
+    sport: GradeScales.FRENCH,
+    boulder: GradeScales.FONT,
+    tr: GradeScales.FRENCH,
+    alpine: GradeScales.FRENCH,
+    mixed: GradeScales.FRENCH,
+    aid: GradeScales.FRENCH,
+    snow: GradeScales.FRENCH, // is this the same as alpine?
+    ice: GradeScales.FRENCH // is this the same as alpine?
+  }
+}
+
+/**
+ * A record of all countries with a default grade context that is not US
+ */
+const COUNTRIES_DEFAULT_NON_US_GRADE_CONTEXT: Record<string, GradeContexts> = {
+	AND: GradeContexts.FR,
+	ATF: GradeContexts.FR,
+	AUS: GradeContexts.AU,
+	AUT: GradeContexts.UIAA,
+	AZE: GradeContexts.UIAA,
+	BEL: GradeContexts.FR,
+	BGR: GradeContexts.UIAA,
+	BIH: GradeContexts.FR,
+	BLR: GradeContexts.UIAA,
+	BRA: GradeContexts.BRZ,
+	BWA: GradeContexts.SA,
+	CHE: GradeContexts.FR,
+	CUB: GradeContexts.FR,
+	CZE: GradeContexts.UIAA,
+	DEU: GradeContexts.UIAA,
+	DNK: GradeContexts.UIAA,
+	EGY: GradeContexts.FR,
+	ESP: GradeContexts.FR,
+	EST: GradeContexts.FR,
+	FIN: GradeContexts.FIN,
+	FRA: GradeContexts.FR,
+	GBR: GradeContexts.UK,
+	GRC: GradeContexts.FR,
+	GUF: GradeContexts.FR,
+	HKG: GradeContexts.HK,
+	HRV: GradeContexts.FR,
+	HUN: GradeContexts.UIAA,
+	IOT: GradeContexts.UK,
+	IRL: GradeContexts.UK,
+	ITA: GradeContexts.FR,
+	JEY: GradeContexts.UK,
+	JOR: GradeContexts.FR,
+	KEN: GradeContexts.UK,
+	KGZ: GradeContexts.FR,
+	LAO: GradeContexts.FR,
+	LIE: GradeContexts.FR,
+	LSO: GradeContexts.SA,
+	LTU: GradeContexts.FR,
+	LUX: GradeContexts.FR,
+	LVA: GradeContexts.FR,
+	MAR: GradeContexts.FR,
+	MCO: GradeContexts.FR,
+	MDA: GradeContexts.FR,
+	MDG: GradeContexts.FR,
+	MKD: GradeContexts.FR,
+	MLT: GradeContexts.FR,
+	MNE: GradeContexts.UIAA,
+	MYS: GradeContexts.FR,
+	NAM: GradeContexts.SA,
+	NCL: GradeContexts.FR,
+	NLD: GradeContexts.FR,
+	NOR: GradeContexts.NWG,
+	NZL: GradeContexts.AU,
+	PER: GradeContexts.FR,
+	PNG: GradeContexts.AU,
+	POL: GradeContexts.POL,
+	PRT: GradeContexts.FR,
+	PYF: GradeContexts.FR,
+	ROU: GradeContexts.FR,
+	RUS: GradeContexts.FR,
+	SGP: GradeContexts.FR,
+	SRB: GradeContexts.FR,
+	SVK: GradeContexts.UIAA,
+	SVN: GradeContexts.FR,
+	SWE: GradeContexts.SWE,
+	THA: GradeContexts.FR,
+	TON: GradeContexts.AU,
+	TUN: GradeContexts.FR,
+	TUR: GradeContexts.FR,
+	UGA: GradeContexts.SA,
+	UKR: GradeContexts.FR,
+	VNM: GradeContexts.FR,
+	ZAF: GradeContexts.SA
+}
+
+/**
+ * 
+ * @returns all countries with their default grade context
+ */
+export const getCountriesDefaultGradeContext = () => {
+  let countries = { ...COUNTRIES_DEFAULT_NON_US_GRADE_CONTEXT }
+  for (const alpha3Code in isoCountries.getAlpha3Codes()) {
+    // Any country not found will have a US Grade Context
+    if (!countries.hasOwnProperty(alpha3Code)) {
+      countries[alpha3Code] = GradeContexts.US
+    }
+  }
+  return countries
+}

--- a/src/grade-utils.ts
+++ b/src/grade-utils.ts
@@ -36,12 +36,12 @@ export enum GradeScales {
 export const getBand = (grade: string, discipline: string | undefined, gradeContext: GradeContexts): GradeBand => {
   // TODO: Merge GradeScale variable with @openbeta/sandbag GradeScale variable
   let boulderScale = sbGradeScales.VScale
-  let routeScale = sbGradeScales.Yds 
+  let routeScale = sbGradeScales.Yds
   if (gradeContext === GradeContexts.FR) {
     boulderScale = sbGradeScales.Font
     routeScale = sbGradeScales.French
   }
-  if (discipline === "boulder") {
+  if (discipline === 'boulder') {
     const score = getScoreForSort(grade, boulderScale)
     return vScoreToBand(score)
   }
@@ -75,7 +75,7 @@ export const gradeContextToGradeScales = {
   [GradeContexts.US]: {
     trad: GradeScales.YDS,
     sport: GradeScales.YDS,
-    boulder: GradeScales.YDS, 
+    boulder: GradeScales.YDS,
     tr: GradeScales.YDS,
     alpine: GradeScales.YDS,
     mixed: GradeScales.YDS,
@@ -100,90 +100,90 @@ export const gradeContextToGradeScales = {
  * A record of all countries with a default grade context that is not US
  */
 const COUNTRIES_DEFAULT_NON_US_GRADE_CONTEXT: Record<string, GradeContexts> = {
-	AND: GradeContexts.FR,
-	ATF: GradeContexts.FR,
-	AUS: GradeContexts.AU,
-	AUT: GradeContexts.UIAA,
-	AZE: GradeContexts.UIAA,
-	BEL: GradeContexts.FR,
-	BGR: GradeContexts.UIAA,
-	BIH: GradeContexts.FR,
-	BLR: GradeContexts.UIAA,
-	BRA: GradeContexts.BRZ,
-	BWA: GradeContexts.SA,
-	CHE: GradeContexts.FR,
-	CUB: GradeContexts.FR,
-	CZE: GradeContexts.UIAA,
-	DEU: GradeContexts.UIAA,
-	DNK: GradeContexts.UIAA,
-	EGY: GradeContexts.FR,
-	ESP: GradeContexts.FR,
-	EST: GradeContexts.FR,
-	FIN: GradeContexts.FIN,
-	FRA: GradeContexts.FR,
-	GBR: GradeContexts.UK,
-	GRC: GradeContexts.FR,
-	GUF: GradeContexts.FR,
-	HKG: GradeContexts.HK,
-	HRV: GradeContexts.FR,
-	HUN: GradeContexts.UIAA,
-	IOT: GradeContexts.UK,
-	IRL: GradeContexts.UK,
-	ITA: GradeContexts.FR,
-	JEY: GradeContexts.UK,
-	JOR: GradeContexts.FR,
-	KEN: GradeContexts.UK,
-	KGZ: GradeContexts.FR,
-	LAO: GradeContexts.FR,
-	LIE: GradeContexts.FR,
-	LSO: GradeContexts.SA,
-	LTU: GradeContexts.FR,
-	LUX: GradeContexts.FR,
-	LVA: GradeContexts.FR,
-	MAR: GradeContexts.FR,
-	MCO: GradeContexts.FR,
-	MDA: GradeContexts.FR,
-	MDG: GradeContexts.FR,
-	MKD: GradeContexts.FR,
-	MLT: GradeContexts.FR,
-	MNE: GradeContexts.UIAA,
-	MYS: GradeContexts.FR,
-	NAM: GradeContexts.SA,
-	NCL: GradeContexts.FR,
-	NLD: GradeContexts.FR,
-	NOR: GradeContexts.NWG,
-	NZL: GradeContexts.AU,
-	PER: GradeContexts.FR,
-	PNG: GradeContexts.AU,
-	POL: GradeContexts.POL,
-	PRT: GradeContexts.FR,
-	PYF: GradeContexts.FR,
-	ROU: GradeContexts.FR,
-	RUS: GradeContexts.FR,
-	SGP: GradeContexts.FR,
-	SRB: GradeContexts.FR,
-	SVK: GradeContexts.UIAA,
-	SVN: GradeContexts.FR,
-	SWE: GradeContexts.SWE,
-	THA: GradeContexts.FR,
-	TON: GradeContexts.AU,
-	TUN: GradeContexts.FR,
-	TUR: GradeContexts.FR,
-	UGA: GradeContexts.SA,
-	UKR: GradeContexts.FR,
-	VNM: GradeContexts.FR,
-	ZAF: GradeContexts.SA
+  AND: GradeContexts.FR,
+  ATF: GradeContexts.FR,
+  AUS: GradeContexts.AU,
+  AUT: GradeContexts.UIAA,
+  AZE: GradeContexts.UIAA,
+  BEL: GradeContexts.FR,
+  BGR: GradeContexts.UIAA,
+  BIH: GradeContexts.FR,
+  BLR: GradeContexts.UIAA,
+  BRA: GradeContexts.BRZ,
+  BWA: GradeContexts.SA,
+  CHE: GradeContexts.FR,
+  CUB: GradeContexts.FR,
+  CZE: GradeContexts.UIAA,
+  DEU: GradeContexts.UIAA,
+  DNK: GradeContexts.UIAA,
+  EGY: GradeContexts.FR,
+  ESP: GradeContexts.FR,
+  EST: GradeContexts.FR,
+  FIN: GradeContexts.FIN,
+  FRA: GradeContexts.FR,
+  GBR: GradeContexts.UK,
+  GRC: GradeContexts.FR,
+  GUF: GradeContexts.FR,
+  HKG: GradeContexts.HK,
+  HRV: GradeContexts.FR,
+  HUN: GradeContexts.UIAA,
+  IOT: GradeContexts.UK,
+  IRL: GradeContexts.UK,
+  ITA: GradeContexts.FR,
+  JEY: GradeContexts.UK,
+  JOR: GradeContexts.FR,
+  KEN: GradeContexts.UK,
+  KGZ: GradeContexts.FR,
+  LAO: GradeContexts.FR,
+  LIE: GradeContexts.FR,
+  LSO: GradeContexts.SA,
+  LTU: GradeContexts.FR,
+  LUX: GradeContexts.FR,
+  LVA: GradeContexts.FR,
+  MAR: GradeContexts.FR,
+  MCO: GradeContexts.FR,
+  MDA: GradeContexts.FR,
+  MDG: GradeContexts.FR,
+  MKD: GradeContexts.FR,
+  MLT: GradeContexts.FR,
+  MNE: GradeContexts.UIAA,
+  MYS: GradeContexts.FR,
+  NAM: GradeContexts.SA,
+  NCL: GradeContexts.FR,
+  NLD: GradeContexts.FR,
+  NOR: GradeContexts.NWG,
+  NZL: GradeContexts.AU,
+  PER: GradeContexts.FR,
+  PNG: GradeContexts.AU,
+  POL: GradeContexts.POL,
+  PRT: GradeContexts.FR,
+  PYF: GradeContexts.FR,
+  ROU: GradeContexts.FR,
+  RUS: GradeContexts.FR,
+  SGP: GradeContexts.FR,
+  SRB: GradeContexts.FR,
+  SVK: GradeContexts.UIAA,
+  SVN: GradeContexts.FR,
+  SWE: GradeContexts.SWE,
+  THA: GradeContexts.FR,
+  TON: GradeContexts.AU,
+  TUN: GradeContexts.FR,
+  TUR: GradeContexts.FR,
+  UGA: GradeContexts.SA,
+  UKR: GradeContexts.FR,
+  VNM: GradeContexts.FR,
+  ZAF: GradeContexts.SA
 }
 
 /**
- * 
+ *
  * @returns all countries with their default grade context
  */
-export const getCountriesDefaultGradeContext = () => {
-  let countries = { ...COUNTRIES_DEFAULT_NON_US_GRADE_CONTEXT }
+export const getCountriesDefaultGradeContext = (): { [x: string]: GradeContexts } => {
+  const countries = { ...COUNTRIES_DEFAULT_NON_US_GRADE_CONTEXT }
   for (const alpha3Code in isoCountries.getAlpha3Codes()) {
     // Any country not found will have a US Grade Context
-    if (!countries.hasOwnProperty(alpha3Code)) {
+    if (!(alpha3Code in countries)) {
       countries[alpha3Code] = GradeContexts.US
     }
   }

--- a/src/graphql/AreaTypeDef.ts
+++ b/src/graphql/AreaTypeDef.ts
@@ -24,6 +24,7 @@ export const typeDef = gql`
     content: AreaContent
     pathHash: String!
     pathTokens: [String]!
+    gradeContext: String!
     density: Float!
     totalClimbs: Int!
     media: [MediaTagType]
@@ -55,6 +56,8 @@ export const typeDef = gql`
     sport: DisciplineStatsType
     boulder: DisciplineStatsType
     alpine: DisciplineStatsType
+    snow: DisciplineStatsType
+    ice: DisciplineStatsType
     mixed: DisciplineStatsType
     aid: DisciplineStatsType
     tr: DisciplineStatsType
@@ -71,6 +74,7 @@ export const typeDef = gql`
   }
 
   type CountByGradeBand {
+    unknown: Int
     beginner: Int
     intermediate: Int
     advance: Int

--- a/src/graphql/ClimbTypeDef.ts
+++ b/src/graphql/ClimbTypeDef.ts
@@ -11,8 +11,9 @@ export const typeDef = gql`
     uuid: ID!
     name: String!
     fa: String!
-    yds: String!
-    grade: GradeType!
+    yds: String! @deprecated(reason: "migrating to grades field")
+    grades: GradeType!
+    gradeContext: String
     type: ClimbType!
     safety: SafetyEnum!
     metadata: ClimbMetadata!
@@ -43,6 +44,8 @@ export const typeDef = gql`
     sport: Boolean
     bouldering: Boolean
     alpine: Boolean
+    snow: Boolean
+    ice: Boolean
     mixed: Boolean
     aid: Boolean
     tr: Boolean

--- a/src/model/AreaDataSource.ts
+++ b/src/model/AreaDataSource.ts
@@ -90,7 +90,12 @@ export default class AreaDataSource extends MongoDataSource<AreaType> {
             from: 'climbs', // other collection name
             localField: 'climbs',
             foreignField: '_id',
-            as: 'climbs' // clobber array of climb IDs with climb objects
+            as: 'climbs', // clobber array of climb IDs with climb objects
+          }
+        },
+        {
+          $set: {
+            'climbs.gradeContext': '$gradeContext' // manually set area's grade context to climb
           }
         }
       ])
@@ -165,7 +170,8 @@ export default class AreaDataSource extends MongoDataSource<AreaType> {
                 $project: { // only include specific fields
                   _id: 0,
                   ancestors: 1,
-                  pathTokens: 1
+                  pathTokens: 1,
+                  gradeContext: 1
                 }
               }
             ]

--- a/src/model/AreaDataSource.ts
+++ b/src/model/AreaDataSource.ts
@@ -90,7 +90,7 @@ export default class AreaDataSource extends MongoDataSource<AreaType> {
             from: 'climbs', // other collection name
             localField: 'climbs',
             foreignField: '_id',
-            as: 'climbs', // clobber array of climb IDs with climb objects
+            as: 'climbs' // clobber array of climb IDs with climb objects
           }
         },
         {

--- a/src/model/MutableAreaDataSource.ts
+++ b/src/model/MutableAreaDataSource.ts
@@ -164,7 +164,8 @@ export default class MutableAreaDataSource extends AreaDataSource {
 
     const parentAncestors = parent.ancestors
     const parentPathTokens = parent.pathTokens
-    const newArea = newAreaHelper(areaName, parentAncestors, parentPathTokens)
+    const parentGradeContext = parent.gradeContext
+    const newArea = newAreaHelper(areaName, parentAncestors, parentPathTokens, parentGradeContext)
     newArea._change = produce(newChangeMeta, draft => {
       draft.seq = 1
     })
@@ -332,7 +333,7 @@ export default class MutableAreaDataSource extends AreaDataSource {
   }
 }
 
-export const newAreaHelper = (areaName: string, parentAncestors: string, parentPathTokens: string[]): AreaType => {
+export const newAreaHelper = (areaName: string, parentAncestors: string, parentPathTokens: string[], parentGradeContext: string): AreaType => {
   const _id = new mongoose.Types.ObjectId()
   const uuid = getUUID(parentPathTokens.join() + areaName, false, undefined)
 
@@ -358,10 +359,12 @@ export const newAreaHelper = (areaName: string, parentAncestors: string, parentP
     ancestors: ancestors,
     climbs: [],
     pathTokens: pathTokens,
+    gradeContext: parentGradeContext,
     aggregate: {
       byGrade: [],
       byDiscipline: {},
       byGradeBand: {
+        unknown: 0,
         beginner: 0,
         intermediate: 0,
         advance: 0,


### PR DESCRIPTION
Overall changes for completing the tasks below to help complete the larger scoped #111.

#157 Create grade contexts defaulted to country level. There is a cascading effect of sub-areas using the parent area's grade context if no grade context is imported into that specified area. This continues to the crag level. Climbs of the crag will inherit that crag's grade context (currently not allowed to import at the climb level).

#140 Add new grades schema that maps to grade context. Updates the area and climb schemas to use the new grades field

#141 Update statistics aggregate function to use new grades field.

---------------------
Noticed some data integrity issues:
- Will we be handling "snow"/"ice" climb types or are these considered "alpine"?
- One climb in the current data set didn't return a climb type. The expectation would be for all climbs to have a climb type.

Todos:
- Moving the getBand/score logic out of openbeta-graphql into sandbag repo, so there's a single source of truth.
- Moving grade scales out of openbeta-graphql into sandbag repo, so there's a single source of truth.
- Add more grade contexts beyond US and FR.
- Add functionality to update the grade context for an area. Should this only be allowed by an admin?