### PR TITLE
Hotfix: fix tag removal

### DIFF
--- a/src/db/MediaTypes.ts
+++ b/src/db/MediaTypes.ts
@@ -50,7 +50,7 @@ export interface ClimbTagType {
 
 export type TagEntryResultType = AreaTagType | ClimbTagType
 
-export interface RemoveTagResult {
+export interface DeleteTagResult {
   mediaUuid: MUUID
   destinationId: MUUID
   removed: boolean

--- a/src/graphql/media/MediaResolvers.ts
+++ b/src/graphql/media/MediaResolvers.ts
@@ -1,4 +1,4 @@
-import { MediaListByAuthorType, MediaType, RefModelType, ClimbTagType, AreaTagType } from '../../db/MediaTypes.js'
+import { MediaListByAuthorType, MediaType, RefModelType, ClimbTagType, AreaTagType, DeleteTagResult } from '../../db/MediaTypes.js'
 const MediaResolvers = {
   MediaTagType: {
     mediaUuid: (node: MediaType) => node.mediaUuid.toUUID().toString(),
@@ -15,6 +15,11 @@ const MediaResolvers = {
       }
       return null
     }
+  },
+
+  DeleteTagResult: {
+    mediaUuid: (node: DeleteTagResult) => node.mediaUuid.toUUID().toString(),
+    destinationId: (node: DeleteTagResult) => node.destinationId.toUUID().toString()
   },
 
   MediaListByAuthorType: {

--- a/src/model/MutableMediaDataSource.ts
+++ b/src/model/MutableMediaDataSource.ts
@@ -2,7 +2,7 @@ import { UserInputError } from 'apollo-server'
 import { MUUID } from 'uuid-mongodb'
 
 import { getMediaModel, getClimbModel, getAreaModel } from '../db/index.js'
-import { MediaType, MediaInputType, RefModelType, TagEntryResultType, RemoveTagResult } from '../db/MediaTypes.js'
+import { MediaType, MediaInputType, RefModelType, TagEntryResultType, DeleteTagResult } from '../db/MediaTypes.js'
 import MediaDataSource from './MediaDataSource.js'
 
 const QUERY_OPTIONS = { upsert: true, new: true, overwrite: false }
@@ -83,7 +83,7 @@ export default class MutableAreaDataSource extends MediaDataSource {
     }
   }
 
-  async removeTag (mediaUuid: MUUID, destinationId: MUUID): Promise<RemoveTagResult|null> {
+  async removeTag (mediaUuid: MUUID, destinationId: MUUID): Promise<DeleteTagResult|null> {
     const rs = await getMediaModel().deleteOne({ mediaUuid, destinationId })
     if (rs?.deletedCount === 1) {
       return { mediaUuid, destinationId, removed: true }


### PR DESCRIPTION
Issue #187 

Defining GQL return type (from any -> `DeleteTagResult`) breaks the frontend