### PR TITLE
Support batch climbs update / add new

### DIFF
--- a/src/GradeUtils.ts
+++ b/src/GradeUtils.ts
@@ -6,7 +6,9 @@ import { DisciplineType, ClimbGradeContextType } from './db/ClimbTypes.js'
  * Grade systems have minor variations between countries. gradeContext is a
  * short abbreviated string that identifies the context in which the grade was assigned
  * and should signify a regional or national variation that may be considered within
- * grade comparisons
+ * grade comparisons.
+ *
+ * Todo:  move this to @openbeta/sandbag library
  */
 export enum GradeContexts {
   /** Alaska (United States) */
@@ -32,6 +34,7 @@ export enum GradeContexts {
 
 /**
  * A conversion from grade context to corresponding grade type / scale
+ * Todo: move this to @openbeta/sandbag
  */
 export const gradeContextToGradeScales: Partial<Record<GradeContexts, ClimbGradeContextType>> = {
   [GradeContexts.US]: {
@@ -65,20 +68,24 @@ export const gradeContextToGradeScales: Partial<Record<GradeContexts, ClimbGrade
  * @param context grade context
  * @returns grade object
  */
-export const createGradeObject = (gradeStr: string, disciplines: DisciplineType, context: ClimbGradeContextType): Partial<Record<GradeScalesTypes, string>> => {
-  const ret: Partial<Record<GradeScalesTypes, string>> = Object.keys(disciplines).reduce((acc, curr) => {
+export const createGradeObject = (gradeStr: string, disciplines: DisciplineType, context: ClimbGradeContextType): Partial<Record<GradeScalesTypes, string>> | null => {
+  return Object.keys(disciplines).reduce<Partial<Record<GradeScalesTypes, string>> | null>((acc, curr) => {
     if (disciplines[curr] === true) {
       const scaleTxt = context[curr]
       const scaleApi = getScale(scaleTxt)
       if (scaleApi != null && !(scaleApi.getScore(gradeStr) < 0)) {
         // only assign valid grade
-        acc[scaleTxt] = gradeStr
+        if (acc == null) {
+          acc = {
+            [scaleTxt]: gradeStr
+          }
+        } else {
+          acc[scaleTxt] = gradeStr
+        }
       }
     }
     return acc
-  }, {})
-
-  return ret
+  }, null)
 }
 
 /**

--- a/src/__tests__/gradeUtils.ts
+++ b/src/__tests__/gradeUtils.ts
@@ -54,11 +54,11 @@ describe('Test grade utilities', () => {
 
     // mismatch input and discipline
     actual = createGradeObject('V4', sanitizeDisciplines({ trad: true }), context)
-    expect(actual).toEqual({})
+    expect(actual).toEqual(null)
 
     // invalid input
     actual = createGradeObject('6a', sanitizeDisciplines({ trad: true }), context)
-    expect(actual).toEqual({})
+    expect(actual).toEqual(null)
   })
 
   it('creates French grade object correctly', () => {
@@ -77,6 +77,6 @@ describe('Test grade utilities', () => {
 
     // Invalid input
     actual = createGradeObject('5.9', sanitizeDisciplines({ bouldering: true }), context)
-    expect(actual).toEqual({})
+    expect(actual).toEqual(null)
   })
 })

--- a/src/auth/permissions.ts
+++ b/src/auth/permissions.ts
@@ -10,7 +10,6 @@ const permissions = shield({
     removeArea: isEditor,
     addArea: isEditor,
     updateArea: isEditor,
-    addClimbs: isEditor,
     updateClimbs: isEditor,
     deleteClimbs: isEditor
   }

--- a/src/db/AreaTypes.ts
+++ b/src/db/AreaTypes.ts
@@ -160,6 +160,8 @@ export interface AreaEditableFieldsType {
   areaName?: string
   description?: string
   isDestination?: boolean
+  isLeaf?: boolean
+  isBoulder?: boolean
   shortCode?: string
   lat?: number
   lng?: number

--- a/src/graphql/climb/ClimbMutations.ts
+++ b/src/graphql/climb/ClimbMutations.ts
@@ -2,22 +2,13 @@ import muid from 'uuid-mongodb'
 import { ContextWithAuth } from '../../types.js'
 
 const ClimbMutations = {
-  addClimbs: async (_, { input }, { dataSources, user }: ContextWithAuth): Promise<string[]> => {
-    const { climbs: ds } = dataSources
-    const { climbs, parentId } = input
-
-    if (user?.uuid == null) throw new Error('Missing user uuid')
-
-    return await ds.addClimbs(user.uuid, muid.from(parentId), climbs)
-  },
-
   updateClimbs: async (_, { input }, { dataSources, user }: ContextWithAuth): Promise<string[]> => {
     const { climbs: ds } = dataSources
     const { changes, parentId } = input
 
     if (user?.uuid == null) throw new Error('Missing user uuid')
 
-    return await ds.updateClimbs(user.uuid, muid.from(parentId), changes)
+    return await ds.addOrUpdateClimbs(user.uuid, muid.from(parentId), changes)
   },
 
   deleteClimbs: async (_, { idList }, { dataSources, user }: ContextWithAuth): Promise<number> => {

--- a/src/graphql/climb/ClimbMutations.ts
+++ b/src/graphql/climb/ClimbMutations.ts
@@ -1,4 +1,4 @@
-import muid from 'uuid-mongodb'
+import muid, { MUUID } from 'uuid-mongodb'
 import { ContextWithAuth } from '../../types.js'
 
 const ClimbMutations = {
@@ -11,12 +11,16 @@ const ClimbMutations = {
     return await ds.addOrUpdateClimbs(user.uuid, muid.from(parentId), changes)
   },
 
-  deleteClimbs: async (_, { idList }, { dataSources, user }: ContextWithAuth): Promise<number> => {
+  deleteClimbs: async (_, { input }, { dataSources, user }: ContextWithAuth): Promise<number> => {
     const { climbs: ds } = dataSources
 
     if (user?.uuid == null) throw new Error('Missing user uuid')
 
-    return await ds.deleteClimbs(user.uuid, idList as string[])
+    const { idList, parentId } = input
+
+    const toBeDeletedList: MUUID[] = idList.map(entry => muid.from(entry))
+
+    return await ds.deleteClimbs(user.uuid, muid.from(parentId), toBeDeletedList)
   }
 }
 

--- a/src/graphql/resolvers.ts
+++ b/src/graphql/resolvers.ts
@@ -141,6 +141,10 @@ const resolvers = {
       }
     },
 
+    yds: (node: ClimbExtType) => node.yds ?? null,
+
+    grades: (node: ClimbExtType) => node.grades ?? null,
+
     metadata: (node: ClimbExtType) => ({
       ...node.metadata,
       leftRightIndex: node.metadata.left_right_index,
@@ -157,6 +161,14 @@ const resolvers = {
       const { areas }: { areas: AreaDataSource } = dataSources
       return await areas.findMediaByClimbId(node._id)
     },
+
+    content: (node: ClimbExtType) => node.content == null
+      ? {
+          description: '',
+          location: '',
+          protection: ''
+        }
+      : node.content,
 
     createdBy: (node: ClimbExtType) => node?.createdBy?.toUUID().toString(),
     updatedBy: (node: ClimbExtType) => node?.updatedBy?.toUUID().toString()
@@ -203,6 +215,7 @@ const resolvers = {
     metadata: (node: AreaType) => ({
       ...node.metadata,
       isDestination: node.metadata?.isDestination ?? false,
+      isBoulder: node.metadata?.isBoulder ?? false,
       leftRightIndex: node.metadata.left_right_index,
       area_id: node.metadata.area_id.toUUID().toString(),
       areaId: node.metadata.area_id.toUUID().toString(),

--- a/src/graphql/schema/AreaEdit.gql
+++ b/src/graphql/schema/AreaEdit.gql
@@ -38,6 +38,8 @@ input AreEditableFieldsInput {
   uuid: String!
   areaName: String
   isDestination: Boolean
+  isLeaf: Boolean
+  isBoulder: Boolean
   shortCode: String
   lat: Float
   lng: Float

--- a/src/graphql/schema/Climb.gql
+++ b/src/graphql/schema/Climb.gql
@@ -16,7 +16,7 @@ type Climb {
   "First ascent, if known. Who was the first person to climb this route?"
   fa: String
   "The grade(s) assigned to this climb. See GradeType documentation"
-  grades: GradeType!
+  grades: GradeType
 
   """
   Grade systems have minor variations between countries.

--- a/src/graphql/schema/ClimbEdit.gql
+++ b/src/graphql/schema/ClimbEdit.gql
@@ -3,7 +3,12 @@ type Mutation {
 }
 
 type Mutation {
-  deleteClimbs(idList: [ID]): Int
+  deleteClimbs(input: DeleteManyClimbsInput): Int
+}
+
+input DeleteManyClimbsInput {
+  parentId: ID
+  idList: [ID]
 }
 
 input UpdateClimbsInput {

--- a/src/graphql/schema/ClimbEdit.gql
+++ b/src/graphql/schema/ClimbEdit.gql
@@ -1,24 +1,9 @@
 type Mutation {
-  addClimbs(input: NewClimbsInput): [ID]
-}
-
-type Mutation {
   updateClimbs(input: UpdateClimbsInput): [ID]
 }
 
 type Mutation {
   deleteClimbs(idList: [ID]): Int
-}
-
-input NewClimbsInput {
-  parentId: ID!
-  climbs: [SingleClimbInput]!
-}
-
-input SingleClimbInput {
-  name: String!
-  disciplines: DisciplineType
-  grade: String
 }
 
 input UpdateClimbsInput {
@@ -27,7 +12,7 @@ input UpdateClimbsInput {
 }
 
 input SingleClimbChangeInput {
-  id: ID!
+  id: ID
   name: String
   disciplines: DisciplineType
   grade: String

--- a/src/model/AreaDataSource.ts
+++ b/src/model/AreaDataSource.ts
@@ -91,7 +91,7 @@ export default class AreaDataSource extends MongoDataSource<AreaType> {
     }
   }
 
-  async findOneAreaByUUID (uuid: muuid.MUUID): Promise<any> {
+  async findOneAreaByUUID (uuid: muuid.MUUID): Promise<AreaType> {
     const rs = await this.areaModel
       .aggregate([
         { $match: { 'metadata.area_id': uuid, _deleting: { $exists: false } } },
@@ -113,7 +113,7 @@ export default class AreaDataSource extends MongoDataSource<AreaType> {
     if (rs != null && rs.length === 1) {
       return rs[0]
     }
-    return null
+    throw new Error(`Area ${uuid.toUUID().toString()} not found.`)
   }
 
   async findManyClimbsByUuids (uuidList: muuid.MUUID[]): Promise<any> {

--- a/src/model/MutableAreaDataSource.ts
+++ b/src/model/MutableAreaDataSource.ts
@@ -133,7 +133,7 @@ export default class MutableAreaDataSource extends AreaDataSource {
     const parent = await this.areaModel.findOne(parentFilter).session(session).orFail(new UserInputError('Expecting 1 parent, found none.'))
 
     if (parent.metadata.leaf || (parent.metadata?.isBoulder ?? false)) {
-      if (parent.children.length > 0) {
+      if (parent.children.length > 0 || parent.climbs.length > 0) {
         throw new UserInputError('Adding new areas to a leaf or boulder area is not allowed.')
       }
       // No children.  It's ok to continue turning an empty crag/boulder into an area.

--- a/src/model/MutableClimbDataSource.ts
+++ b/src/model/MutableClimbDataSource.ts
@@ -196,7 +196,7 @@ export default class MutableClimbDataSource extends ClimbDataSource {
    * @param changes
    * @returns a list of updated (or newly added) climb IDs
    */
-  async addOrUpdateClimbs (userId: MUUID, parentId, changes): Promise<string[]> {
+  async addOrUpdateClimbs (userId: MUUID, parentId: MUUID, changes: ClimbChangeInputType[]): Promise<string[]> {
     const session = await this.areaModel.startSession()
     let ret: string[]
 

--- a/src/model/__tests__/updateAreas.ts
+++ b/src/model/__tests__/updateAreas.ts
@@ -11,7 +11,6 @@ describe('Areas', () => {
   const testUser = muuid.v4()
 
   beforeAll(async () => {
-    console.log('#BeforeAll Areas')
     await connectDB()
 
     try {
@@ -162,8 +161,7 @@ describe('Areas', () => {
       muuid.from(wa.metadata.area_id).toUUID()
     ])
 
-    const deletedAreaInDb = await areas.findOneAreaByUUID(ca.metadata.area_id)
-    expect(deletedAreaInDb).toBeNull()
+    await expect(areas.findOneAreaByUUID(ca.metadata.area_id)).rejects.toThrow(/Area.*not found/)
   })
 
   it('should not delete a subarea containing children', async () => {

--- a/src/model/__tests__/updateAreas.ts
+++ b/src/model/__tests__/updateAreas.ts
@@ -3,11 +3,13 @@ import muuid from 'uuid-mongodb'
 import { geometry } from '@turf/helpers'
 
 import MutableAreaDataSource, { createInstance } from '../MutableAreaDataSource.js'
+import MutableClimbDataSource, { createInstance as createNewClimbDS } from '../MutableClimbDataSource.js'
 import { connectDB, createIndexes, getAreaModel, getClimbModel } from '../../db/index.js'
 import { AreaEditableFieldsType } from '../../db/AreaTypes.js'
 
 describe('Areas', () => {
   let areas: MutableAreaDataSource
+  let climbs: MutableClimbDataSource
   const testUser = muuid.v4()
 
   beforeAll(async () => {
@@ -21,6 +23,7 @@ describe('Areas', () => {
     }
     await createIndexes()
     areas = createInstance()
+    climbs = createNewClimbDS()
   })
 
   afterAll(async () => {
@@ -72,6 +75,29 @@ describe('Areas', () => {
       expect(theBug.pathTokens)
         .toEqual([canada.area_name, theBug.area_name])
     }
+  })
+
+  it('should allow adding child areas to empty leaf area', async () => {
+    let parent = await areas.addArea(testUser, 'My house', null, 'can')
+    await areas.updateArea(testUser, parent.metadata.area_id, { isLeaf: true, isBoulder: true })
+
+    const newClimb = await climbs.addOrUpdateClimbs(testUser, parent.metadata.area_id, [{ name: 'Big Mac' }])
+
+    // Try to add a new area when there's already a climb
+    await expect(areas.addArea(testUser, 'Kitchen', parent.metadata.area_id)).rejects.toThrow(/Adding new areas to a leaf or boulder area is not allowed/)
+
+    // Now remove the climb to see if we can add the area
+
+    await climbs.deleteClimbs(testUser, parent.metadata.area_id, [muuid.from(newClimb[0])])
+    await areas.addArea(testUser, 'Kitchen', parent.metadata.area_id)
+
+    // Reload the parent
+    parent = await areas.findOneAreaByUUID(parent.metadata.area_id)
+    expect(parent.climbs).toHaveLength(0)
+    expect(parent.children).toHaveLength(1)
+    // make sure leaf and boulder flag are cleared
+    expect(parent.metadata.leaf).toBeFalsy()
+    expect(parent.metadata.isBoulder).toBeFalsy()
   })
 
   it('should create an area using only country code (without parent id)', async () => {


### PR DESCRIPTION
Issue #199 
- [x] Consolidate add new and update existing.  updateClimbs mutation now supports upsert.  If climb.id to be updated not provided or not found in the DB then it's an insert
- [x] Support setting Area.isBoulder and leaf 
- [x] Support adding child areas to empty leaf/boulder 