### PR TITLE
Posts

### DIFF
--- a/src/db/PostSchema.ts
+++ b/src/db/PostSchema.ts
@@ -1,17 +1,22 @@
 import mongoose from 'mongoose'
 import mongooseLeanVirtuals from 'mongoose-lean-virtuals'
-
+import muuid from 'uuid-mongodb'
 import { PostType } from './PostTypes.js'
+import { XMediaSchema } from './XMediaSchema.js'
 
 const { Schema } = mongoose
 
 const PostSchema = new Schema<PostType>({
   userId: {
-    type: Schema.Types.ObjectId,
-    required: true
+    type: 'object',
+    value: { type: 'Buffer' },
+    default: () => muuid.v4(),
+    required: true,
+    unique: false,
+    index: true
   },
-  mediaIds: {
-    type: [Schema.Types.ObjectId],
+  xMedia: {
+    type: [XMediaSchema],
     required: true
   },
   description: { type: String }

--- a/src/db/PostTypes.ts
+++ b/src/db/PostTypes.ts
@@ -1,14 +1,17 @@
 import mongoose from 'mongoose'
+import { MUUID } from 'uuid-mongodb'
+import { XMediaType } from './XMediaTypes'
 export interface PostType {
-  userId: mongoose.Types.ObjectId
-  mediaIds: mongoose.Types.ObjectId[]
+  userId: MUUID
+  xMedia: XMediaType[]
   description?: string
 }
 
 export interface AddPostInputType {
-  userId: mongoose.Types.ObjectId
-  mediaIds: mongoose.Types.ObjectId[]
+  photoUrls: string[]
+  userId: string
   description?: string
+  mediaType: number
 }
 
 export interface RemovePostInputType {

--- a/src/db/XMediaSchema.ts
+++ b/src/db/XMediaSchema.ts
@@ -6,7 +6,7 @@ import { XMediaType } from './XMediaTypes.js'
 
 const { Schema } = mongoose
 
-const XMediaSchema = new Schema<XMediaType>({
+export const XMediaSchema = new Schema<XMediaType>({
   userId: {
     type: 'object',
     value: { type: 'Buffer' },
@@ -22,14 +22,6 @@ const XMediaSchema = new Schema<XMediaType>({
   mediaUrl: {
     type: Schema.Types.String,
     required: true
-  },
-  mediaUuid: {
-    type: 'object',
-    value: { type: 'Buffer' },
-    default: () => muuid.v4(),
-    required: true,
-    unique: false,
-    index: true
   },
   tagIds: {
     type: [Schema.Types.ObjectId],

--- a/src/db/XMediaTypes.ts
+++ b/src/db/XMediaTypes.ts
@@ -5,9 +5,8 @@ export interface XMediaType {
   _id?: mongoose.Types.ObjectId
   userId: MUUID
   mediaType: number // 0: photo
-  mediaUuid: MUUID
   mediaUrl: string
-  tagIds: mongoose.Types.ObjectId[]
+  tagIds?: mongoose.Types.ObjectId[]
 }
 
 export interface RemoveXMediaInputType {

--- a/src/db/index.ts
+++ b/src/db/index.ts
@@ -6,6 +6,8 @@ import { getAreaModel } from './AreaSchema.js'
 import { getClimbModel } from './ClimbSchema.js'
 import { getMediaModel } from './MediaSchema.js'
 import { getTickModel } from './TickSchema.js'
+import { getXMediaModel } from './XMediaSchema.js'
+import { getPostModel } from './PostSchema.js'
 import { getChangeLogModel } from './ChangeLogSchema.js'
 import { logger } from '../logger.js'
 import streamListener from './edit/streamListener.js'
@@ -63,6 +65,8 @@ export const createIndexes = async (): Promise<void> => {
   await getAreaModel().createIndexes()
   await getMediaModel().createIndexes()
   await getTickModel().createIndexes()
+  await getXMediaModel().createIndexes()
+  await getPostModel().createIndexes()
 }
 
 export const gracefulExit = async (exitCode: number = 0): Promise<void> => {
@@ -81,4 +85,4 @@ export const defaultPostConnect = async (): Promise<void> => {
 // eslint-disable-next-line
 process.on('SIGINT', gracefulExit).on('SIGTERM', gracefulExit)
 
-export { getMediaModel, getAreaModel, getTickModel, getClimbModel, getChangeLogModel }
+export { getMediaModel, getAreaModel, getTickModel, getClimbModel, getChangeLogModel, getXMediaModel, getPostModel }

--- a/src/graphql/schema/Post.gql
+++ b/src/graphql/schema/Post.gql
@@ -1,5 +1,5 @@
 type Mutation {
-  addPost(input: AddPostInput): AddPostResponse
+  addPost(input: AddPostInput): Post
   removePost(input: RemovePostInput): RemovePostResponse
 }
 
@@ -15,7 +15,7 @@ input GetPostsInput {
 "Input params for creating a new post"
 input AddPostInput {
   userId: ID!
-  mediaIds: [ID]!
+  photoUrls: [String]!
   description: String
 }
 
@@ -40,6 +40,6 @@ type GetPostsResponse {
 type Post {
   _id: ID
   userId: ID!
-  mediaIds: [ID]!
+  xMedia: [XMedia]!
   description: String
 }

--- a/src/graphql/schema/XMedia.gql
+++ b/src/graphql/schema/XMedia.gql
@@ -2,10 +2,7 @@
 # It is used to link media to the Post documents.
 
 type Mutation {
-  # addXMedia
-  addXMedia(input: AddXMediaInput): AddXMediaResponse
-
-  # removeXMedia
+  addXMedia(input: AddXMediaInput): XMedia
   removeXMedia(input: RemoveXMediaInput): RemoveXMediaResponse
 }
 
@@ -18,13 +15,8 @@ type Query {
 input AddXMediaInput {
   userId: ID!
   mediaType: Int!
-  mediaUuid: ID!
   mediaUrl: String!
   tagIds: [ID]
-}
-
-type AddXMediaResponse {
-  xMediaId: ID
 }
 
 input RemoveXMediaInput {
@@ -48,7 +40,6 @@ type XMedia {
   _id: ID
   userId: ID!
   mediaType: Int!
-  mediaUuid: ID!
   mediaUrl: String!
   tagIds: [ID]
 }

--- a/src/graphql/xmedia/mutations.ts
+++ b/src/graphql/xmedia/mutations.ts
@@ -1,22 +1,34 @@
 import { XMediaType, RemoveXMediaInputType } from '../../db/XMediaTypes'
 import { getXMediaModel } from '../../db/XMediaSchema.js'
-import muid from 'uuid-mongodb'
+import { DataSourcesType } from '../../types'
 
 const XMediaMutations = {
   // addXMedia
-  addXMedia: async (_: any, { input }: {input: XMediaType}) => {
-    const XMediaModel = getXMediaModel()
-    const newXMedia = new XMediaModel({
-      ...input,
-      userId: muid.from(input.userId),
-      mediaUuid: muid.from(input.mediaUuid)
-    })
-    const res = await XMediaModel.create(newXMedia)
-    return { xMediaId: res.id }
+  addXMedia: async (
+    _: any,
+    { input }: { input: XMediaType },
+    { dataSources }
+  ) => {
+    const { xmedia }: DataSourcesType = dataSources
+
+    try {
+      const newXMedia = await xmedia.addXMedia({
+        userId: input.userId,
+        mediaType: input.mediaType,
+        mediaUrl: input.mediaUrl
+      })
+      if (newXMedia == null) {
+        console.error(`Failed to add xMedia with url: ${input.mediaUrl}`)
+      }
+      return { xMediaId: newXMedia }
+    } catch (ex) {
+      console.error('Error adding new Post', ex)
+      return ex
+    }
   },
 
   // removeXMedia
-  removeXMedia: async (_: any, { input }: {input: RemoveXMediaInputType}) => {
+  removeXMedia: async (_: any, { input }: { input: RemoveXMediaInputType }) => {
     const XMediaModel = getXMediaModel()
     const res = await XMediaModel.deleteOne({ _id: input.xMediaId })
     return { numDeleted: res.deletedCount }

--- a/src/main.ts
+++ b/src/main.ts
@@ -11,10 +11,15 @@ import { createInstance as createNewClimbDS } from './model/MutableClimbDataSour
 import TickDataSource from './model/TickDataSource.js'
 import { createContext, permissions } from './auth/index.js'
 import { logger } from './logger.js'
+import XMediaDataSource from './model/XMediaDataSource.js'
+import PostDataSource from './model/PostDataSource.js'
 
 // eslint-disable-next-line
-(async function (): Promise<void> {
-  const schema = applyMiddleware(graphqlSchema, permissions.generate(graphqlSchema))
+;(async function (): Promise<void> {
+  const schema = applyMiddleware(
+    graphqlSchema,
+    permissions.generate(graphqlSchema)
+  )
   const server = new ApolloServer({
     introspection: true,
     schema,
@@ -24,7 +29,11 @@ import { logger } from './logger.js'
       areas: createNewAreaDS(),
       ticks: new TickDataSource(mongoose.connection.db.collection('ticks')),
       history: changelogDataSource, // see source for explantion why we don't instantiate the object
-      media: new MutableMediaDataSource(mongoose.connection.db.collection('media'))
+      media: new MutableMediaDataSource(
+        mongoose.connection.db.collection('media')
+      ),
+      xmedia: new XMediaDataSource(mongoose.connection.db.collection('xmedia')),
+      post: new PostDataSource(mongoose.connection.db.collection('post'))
     }),
     cache: 'bounded'
   })
@@ -33,9 +42,11 @@ import { logger } from './logger.js'
 
   const port = 4000
 
-  await server.listen({
-    port
-  }).then((): void => {
-    logger.info(`🚀 Server ready at http://localhost:${port}`)
-  })
+  await server
+    .listen({
+      port
+    })
+    .then((): void => {
+      logger.info(`🚀 Server ready at http://localhost:${port}`)
+    })
 })()

--- a/src/model/PostDataSource.ts
+++ b/src/model/PostDataSource.ts
@@ -1,0 +1,37 @@
+import { MongoDataSource } from 'apollo-datasource-mongodb'
+import { PostType } from '../db/PostTypes'
+import { getPostModel } from '../db/index.js'
+
+export default class PostDataSource extends MongoDataSource<PostType> {
+  postModel = getPostModel()
+
+  /**
+   * @param post
+   * takes in a new post
+   * @returns
+   * returns that new post
+   */
+  async addPost ({
+    userId,
+    xMedia,
+    description
+  }: PostType): Promise<PostType | null> {
+    try {
+      const doc: PostType = {
+        userId,
+        xMedia,
+        description
+      }
+
+      const res: PostType = await this.postModel.create({ ...doc })
+      return res
+    } catch (ex) {
+      console.error('Failed to add post:', ex)
+      return null
+    }
+  }
+
+  // Delete Post
+
+  // Edit Post
+}

--- a/src/model/XMediaDataSource.ts
+++ b/src/model/XMediaDataSource.ts
@@ -1,0 +1,37 @@
+import { MongoDataSource } from 'apollo-datasource-mongodb'
+import { XMediaType } from '../db/XMediaTypes'
+import { getXMediaModel } from '../db/index.js'
+
+export default class XMediaDataSource extends MongoDataSource<XMediaType> {
+  xMediaModel = getXMediaModel()
+
+  /**
+   * @param xMedia
+   * takes in a new xMedia
+   * @returns
+   * returns that new xMedia
+   */
+  async addXMedia ({
+    userId,
+    mediaType,
+    mediaUrl
+  }: XMediaType): Promise<XMediaType | null> {
+    try {
+      const doc: XMediaType = {
+        userId,
+        mediaType,
+        mediaUrl
+      }
+
+      const res: XMediaType = await this.xMediaModel.create({ ...doc })
+      return res
+    } catch (ex) {
+      console.error('Failed to add XMedia:', ex)
+      return null
+    }
+  }
+
+  // Delete XMedia
+
+  // Edit XMedia
+}

--- a/src/types.ts
+++ b/src/types.ts
@@ -7,6 +7,8 @@ import type TickDataSource from './model/TickDataSource.js'
 import type HistoryDataSouce from './model/ChangeLogDataSource.js'
 import type MutableMediaDataSource from './model/MutableMediaDataSource.js'
 import MutableClimbDataSource from './model/MutableClimbDataSource.js'
+import XMediaDataSource from './model/XMediaDataSource.js'
+import PostDataSource from './model/PostDataSource.js'
 
 export enum SortDirection {
   ASC = 1,
@@ -72,6 +74,8 @@ export interface DataSourcesType {
   history: HistoryDataSouce
   media: MutableMediaDataSource
   climbs: MutableClimbDataSource
+  xmedia: XMediaDataSource
+  post: PostDataSource
 }
 
 export interface Context {


### PR DESCRIPTION
This should not disturb the flow of how we currently upload photos today.

Changes:

- Create XMedia and Post data sources and move the DB operations from mutations to data sources.
- Instead of embedding XMedia IDs, we should embed the XMedia documents themselves. 
- Inputs for addPost takes in photoUrls instead of mediaIds. Photo URLs are generated on the front after a photo has been uploaded. PhotoUrl(s) are used to create a xmedia document(s) which finally get added to a Post Document.