### PR TITLE
(obsolete) feat: GradeType "UIAA" and datafield "bolts"

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -114,10 +114,7 @@ tmp
 
 # VSCode
 *.code-workspace
- .vscode/settings.json
 
 # DB Export
 /export/
 /openbeta-export/
-*.code-workspace
-.vscode/settings.json

--- a/.gitignore
+++ b/.gitignore
@@ -114,3 +114,5 @@ tmp
 
 /export/
 /openbeta-export/
+*.code-workspace
+.vscode/settings.json

--- a/.gitignore
+++ b/.gitignore
@@ -112,5 +112,10 @@ tmp
 .idea/
 *.iml
 
+# VSCode
+*.code-workspace
+ .vscode/settings.json
+
+# DB Export
 /export/
 /openbeta-export/

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -12,5 +12,5 @@
   "standard.enable": true,
   "standard.autoFixOnSave": true,
   "standard.engine": "ts-standard",
-  "standard.treatErrorsAsWarnings": true
+  "standard.treatErrorsAsWarnings": true,
 }

--- a/src/GradeUtils.ts
+++ b/src/GradeUtils.ts
@@ -25,6 +25,7 @@ export enum GradeContexts {
   /** Sweden */
   SWE = 'SWE',
   SX = 'SX',
+  /** Central Europe */
   UIAA = 'UIAA',
   /** United Kingdom */
   UK = 'UK',

--- a/src/db/ClimbSchema.ts
+++ b/src/db/ClimbSchema.ts
@@ -63,7 +63,8 @@ const GradeTypeSchema = new Schema<GradeScalesTypes>({
   vscale: Schema.Types.String,
   yds: { type: Schema.Types.String, required: false },
   french: { type: Schema.Types.String, required: false },
-  font: { type: Schema.Types.String, required: false }
+  font: { type: Schema.Types.String, required: false },
+  UIAA: { type: Schema.Types.String, required: false }
 }, { _id: false })
 
 export const ClimbSchema = new Schema<ClimbType>({

--- a/src/db/ClimbTypes.ts
+++ b/src/db/ClimbTypes.ts
@@ -40,6 +40,10 @@ export interface IClimbProps {
 
   /** Total length in metersif known.  We will support individual pitch lenth in the future. */
   length?: number
+
+  /** Total number of bolts (fixed anchors). Especially relevant for sport climbs. */
+  bolts?: number
+
   /**
    * Grades appear within as an I18n-safe format.
    * We achieve this via a larger data encapsulation, and perform interpretation and comparison
@@ -155,13 +159,14 @@ export interface ClimbChangeInputType {
   protection?: string
   fa?: string
   length?: number
+  bolts?: number
   experimentalAuthor?: {
     displayName: string
     url: string
   }
 }
 
-type UpdatableClimbFieldsType = Pick<ClimbType, 'fa' | 'name' | 'type' | 'gradeContext' | 'grades' | 'content' | 'length'>
+type UpdatableClimbFieldsType = Pick<ClimbType, 'fa' | 'name' | 'type' | 'gradeContext' | 'grades' | 'content' | 'length' | 'bolts'>
 /**
  * Minimum required fields when adding a new climb or boulder problem
  */

--- a/src/db/ClimbTypes.ts
+++ b/src/db/ClimbTypes.ts
@@ -38,10 +38,10 @@ export interface IClimbProps {
   fa?: string
   yds?: string
 
-  /** Total length in metersif known.  We will support individual pitch lenth in the future. */
+  /** Total length in meters, if known.  We will support individual pitch lenth in the future. */
   length?: number
 
-  /** Total number of bolts (fixed anchors). Especially relevant for sport climbs. */
+  /** Total number of bolts (fixed anchors), if known. Especially relevant for sport climbs. */
   bolts?: number
 
   /**

--- a/src/db/ClimbTypes.ts
+++ b/src/db/ClimbTypes.ts
@@ -88,6 +88,7 @@ export interface IGradeType {
   yds?: string
   french?: string
   font?: string
+  uiaa?: string
 }
 
 /**

--- a/src/db/import/ClimbTransformer.ts
+++ b/src/db/import/ClimbTransformer.ts
@@ -26,7 +26,8 @@ const transformClimbRecord = (row: any): ClimbType => {
       ...boulderingDiscipline,
       yds: grade.YDS,
       font: grade.Font,
-      french: grade.French
+      french: grade.French,
+      uiaa: grade.UIAA
     },
     gradeContext: gradeContext,
     safety: safety,

--- a/src/graphql/resolvers.ts
+++ b/src/graphql/resolvers.ts
@@ -145,6 +145,8 @@ const resolvers = {
 
     length: (node: ClimbGQLQueryType) => node.length ?? -1,
 
+    bolts: (node: ClimbGQLQueryType) => node.bolts ?? -1,
+
     grades: (node: ClimbGQLQueryType) => node.grades ?? null,
 
     metadata: (node: ClimbGQLQueryType) => ({

--- a/src/graphql/schema/Climb.gql
+++ b/src/graphql/schema/Climb.gql
@@ -19,6 +19,9 @@ type Climb {
   "Total length in meters if known (-1 otherwise)"
   length: Int!
 
+  "Number of bolts (permanent anchors fixed into the rock). Especially relevant for sport climbing."
+  bolts: Int!
+
   "The grade(s) assigned to this climb. See GradeType documentation"
   grades: GradeType
 

--- a/src/graphql/schema/Climb.gql
+++ b/src/graphql/schema/Climb.gql
@@ -16,10 +16,10 @@ type Climb {
   "First ascent, if known. Who was the first person to climb this route?"
   fa: String
 
-  "Total length in meters if known (-1 otherwise)"
+  "Total length in meters, if known (-1 otherwise)"
   length: Int!
 
-  "Number of bolts (permanent anchors fixed into the rock). Especially relevant for sport climbing."
+  "Number of bolts/permanent anchors, if known (-1 otherwise). Especially relevant for sport climbing."
   bolts: Int!
 
   "The grade(s) assigned to this climb. See GradeType documentation"

--- a/src/graphql/schema/Climb.gql
+++ b/src/graphql/schema/Climb.gql
@@ -149,6 +149,12 @@ type GradeType {
   https://www.99boulders.com/bouldering-grades#font-scale-aka-fontainebleau-scale
   """
   font: String
+  """
+  UIAA grading system, typically used in Central Europe (e.g. Germany, Austria, Switzerland). Uses Roman numerals with +/- signs, e.g. "VII", "VII-" (easier), or "VII+" (harder).
+  Used for sport climbing and alpine climbing.
+  https://en.wikipedia.org/wiki/Grade_(climbing)#UIAA
+  """
+  uiaa: String
 }
 
 """


### PR DESCRIPTION
OpenBeta misses some database fields/types to cover the needs for climbs in Central Europe (Germany, Austria, Switzerland, etc.). For one, the UIAA grading system. For the other, the number of bolts (fixed anchors) for a climb, as sport climbs are the vast majority, trad climbs are more of a niche.