### PR TITLE
add UIAA gradetype

### DIFF
--- a/src/GradeUtils.ts
+++ b/src/GradeUtils.ts
@@ -90,11 +90,12 @@ export const gradeContextToGradeScales: Partial<Record<GradeContexts, ClimbGrade
     sport: GradeScales.UIAA,
     bouldering: GradeScales.FONT,
     tr: GradeScales.UIAA,
+    deepwatersolo: GradeScales.FRENCH,
     alpine: GradeScales.UIAA,
     mixed: GradeScales.UIAA, // TODO: change to MI scale, once added
     aid: GradeScales.UIAA,
     snow: GradeScales.UIAA, // TODO: remove `snow` since it duplicates `ice`
-    ice: GradeScales.UIAA // TODO: change to WI scale, once added
+    ice: GradeScales.WI
   }
 }
 

--- a/src/GradeUtils.ts
+++ b/src/GradeUtils.ts
@@ -84,6 +84,17 @@ export const gradeContextToGradeScales: Partial<Record<GradeContexts, ClimbGrade
     aid: GradeScales.AID,
     snow: GradeScales.FRENCH, // SA does not have a whole lot of snow
     ice: GradeScales.WI
+  },
+  [GradeContexts.UIAA]: {
+    trad: GradeScales.UIAA,
+    sport: GradeScales.UIAA,
+    bouldering: GradeScales.FONT,
+    tr: GradeScales.UIAA,
+    alpine: GradeScales.UIAA,
+    mixed: GradeScales.UIAA, // TODO: change to MI scale, once added
+    aid: GradeScales.UIAA,
+    snow: GradeScales.UIAA, // TODO: remove `snow` since it duplicates `ice`
+    ice: GradeScales.UIAA // TODO: change to WI scale, once added
   }
 }
 

--- a/src/db/ClimbSchema.ts
+++ b/src/db/ClimbSchema.ts
@@ -64,7 +64,8 @@ const GradeTypeSchema = new Schema<GradeScalesTypes>({
   yds: { type: Schema.Types.String, required: false },
   ewbank: { type: Schema.Types.String, required: false },
   french: { type: Schema.Types.String, required: false },
-  font: { type: Schema.Types.String, required: false }
+  font: { type: Schema.Types.String, required: false },
+  UIAA: { type: Schema.Types.String, required: false }
 }, { _id: false })
 
 export const ClimbSchema = new Schema<ClimbType>({

--- a/src/db/ClimbTypes.ts
+++ b/src/db/ClimbTypes.ts
@@ -89,6 +89,7 @@ export interface IGradeType {
   ewbank?: string
   french?: string
   font?: string
+  uiaa?: string
 }
 
 /**

--- a/src/db/ClimbTypes.ts
+++ b/src/db/ClimbTypes.ts
@@ -151,7 +151,7 @@ export interface ClimbChangeInputType {
   id?: string
   name?: string
   disciplines?: DisciplineType
-  grade?: string
+  grade?: string // actual grade value (e.g. "7a", "5+")
   leftRightIndex?: number
   description?: string
   location?: string

--- a/src/db/import/ClimbTransformer.ts
+++ b/src/db/import/ClimbTransformer.ts
@@ -27,7 +27,8 @@ const transformClimbRecord = (row: any): ClimbType => {
       yds: grade.YDS,
       ewbank: grade.Ewbank,
       font: grade.Font,
-      french: grade.French
+      french: grade.French,
+      uiaa: grade.UIAA
     },
     gradeContext,
     safety,

--- a/src/graphql/schema/Climb.gql
+++ b/src/graphql/schema/Climb.gql
@@ -156,7 +156,7 @@ type GradeType {
   font: String
   """
   UIAA grading system, typically used in Central Europe (e.g. Germany, Austria, Switzerland).
-  Uses Roman numerals, e.g. "7-", "7", "7+". (Arabic numerals, like "VII-", are not supported).
+  Uses Arabic numerals, e.g. "7-", "7", "7+". (Roman numerals, like "VII-", are not supported).
   https://en.wikipedia.org/wiki/Grade_(climbing)#UIAA
   """
   uiaa: String

--- a/src/graphql/schema/Climb.gql
+++ b/src/graphql/schema/Climb.gql
@@ -154,6 +154,12 @@ type GradeType {
   https://www.99boulders.com/bouldering-grades#font-scale-aka-fontainebleau-scale
   """
   font: String
+  """
+  UIAA grading system, typically used in Central Europe (e.g. Germany, Austria, Switzerland).
+  Uses Roman numerals, e.g. "7-", "7", "7+". (Arabic numerals, like "VII-", are not supported).
+  https://en.wikipedia.org/wiki/Grade_(climbing)#UIAA
+  """
+  uiaa: String
 }
 
 """

--- a/src/model/__tests__/MutableClimbDataSource.ts
+++ b/src/model/__tests__/MutableClimbDataSource.ts
@@ -348,6 +348,36 @@ describe('Climb CRUD', () => {
     }
   })
 
+  it('handles UIAA grades correctly', async () => {
+    await areas.addCountry('deu') // Assuming Germany since UIAA is dominant grading system
+
+    // A roped climbing area
+    const newClimbingArea = await areas.addArea(testUser, 'Climbing area 1', null, 'deu')
+    if (newClimbingArea == null) fail('Expect new area to be created')
+
+    const newIDs = await climbs.addOrUpdateClimbs(
+      testUser,
+      newClimbingArea.metadata.area_id,
+      [{ ...newSportClimb1, grade: '6+' }, // good UIAA grade
+        { ...newSportClimb2, grade: '7-' }, // good UIAA grade
+        { ...newSportClimb2, grade: '5' }, // good UIAA grade
+        { ...newSportClimb1, grade: 'V6' }]) // bad UIAA grade (V-scale used)
+
+    expect(newIDs).toHaveLength(4)
+
+    const climb1 = await climbs.findOneClimbByMUUID(muid.from(newIDs[0]))
+    expect(climb1?.grades).toEqual({ uiaa: '6+' })
+
+    const climb2 = await climbs.findOneClimbByMUUID(muid.from(newIDs[1]))
+    expect(climb2?.grades).toEqual({ uiaa: '7-' })
+
+    const climb3 = await climbs.findOneClimbByMUUID(muid.from(newIDs[2]))
+    expect(climb3?.grades).toEqual({ uiaa: '5' })
+
+    const climb4 = await climbs.findOneClimbByMUUID(muid.from(newIDs[3]))
+    expect(climb4?.grades).toEqual(undefined)
+  })
+
   it('can update boulder problems', async () => {
     const newDestination = await areas.addArea(testUser, 'Bouldering area A100', null, 'fr')
 


### PR DESCRIPTION
OpenBeta misses some database fields/types to cover the needs for climbs in Central Europe (Germany, Austria, Switzerland, etc.). For one, the UIAA grading system. For the other, the number of bolts (fixed anchors) for a climb, as sport climbs are the vast majority, trad climbs are more of a niche.