### PR TITLE
Add _change checks to integration tests

### DIFF
--- a/src/db/index.ts
+++ b/src/db/index.ts
@@ -1,4 +1,5 @@
 import mongoose from 'mongoose'
+import { ChangeStream } from 'mongodb'
 import { config } from 'dotenv'
 import { enableAllPlugins } from 'immer'
 
@@ -79,10 +80,10 @@ export const gracefulExit = async (exitCode: number = 0): Promise<void> => {
   })
 }
 
-export const defaultPostConnect = async (): Promise<void> => {
+export const defaultPostConnect = async (): Promise<ChangeStream> => {
   console.log('Kudos!')
   await createIndexes()
-  await streamListener()
+  return await streamListener()
 }
 
 // eslint-disable-next-line

--- a/src/model/ChangeLogDataSource.ts
+++ b/src/model/ChangeLogDataSource.ts
@@ -3,9 +3,10 @@ import { MongoDataSource } from 'apollo-datasource-mongodb'
 import { MUUID } from 'uuid-mongodb'
 
 import { getChangeLogModel } from '../db/index.js'
-import { ChangeLogType, OpType, BaseChangeRecordType, AreaChangeLogType, ClimbChangeLogType } from '../db/ChangeLogType'
+import { ChangeLogType, OpType, BaseChangeRecordType, AreaChangeLogType, ClimbChangeLogType, OrganizationChangeLogType } from '../db/ChangeLogType'
 import { logger } from '../logger.js'
 import { areaHistoryDataSource } from './AreaHistoryDatasource.js'
+import { organizationHistoryDataSource } from './OrganizationHistoryDatasource.js'
 
 export default class ChangeLogDataSource extends MongoDataSource<ChangeLogType> {
   changeLogModel = getChangeLogModel()
@@ -57,6 +58,10 @@ export default class ChangeLogDataSource extends MongoDataSource<ChangeLogType> 
 
   async getAreaChangeSets (areaUuid?: MUUID): Promise<AreaChangeLogType[]> {
     return await areaHistoryDataSource.getChangeSetsByUuid(areaUuid)
+  }
+
+  async getOrganizationChangeSets (orgId?: MUUID): Promise<OrganizationChangeLogType[]> {
+    return await organizationHistoryDataSource.getChangeSetsByOrgId(orgId)
   }
 
   /**

--- a/src/model/OrganizationHistoryDatasource.ts
+++ b/src/model/OrganizationHistoryDatasource.ts
@@ -1,0 +1,65 @@
+import { MongoDataSource } from 'apollo-datasource-mongodb'
+import { MUUID } from 'uuid-mongodb'
+import { OrganizationChangeLogType } from '../db/ChangeLogType.js'
+import { getChangeLogModel } from '../db/index.js'
+
+export class OrganizationHistoryDataSource extends MongoDataSource<OrganizationChangeLogType> {
+  changelogModel = getChangeLogModel()
+
+  async getChangeSetsByOrgId (orgId?: MUUID): Promise<OrganizationChangeLogType[]> {
+    let rs
+    if (orgId == null) {
+      // No orgId specified: return all changes
+      const filter: any = {
+        $match: {
+          'changes.kind': 'organizations'
+        }
+      }
+
+      rs = await this.changelogModel.aggregate([
+        filter,
+        {
+          $sort: {
+            createdAt: -1
+          }
+        }
+      ])
+      return rs as OrganizationChangeLogType[]
+    } else {
+      const filter = {
+        $match: {
+          changes: {
+            $elemMatch:
+              { 'fullDocument.orgId': orgId, kind: 'organizations' }
+          }
+        }
+      }
+
+      const rs2 = await this.changelogModel
+        .aggregate([
+          filter,
+          // https://github.com/Automattic/mongoose/issues/12415
+          // {
+          //   $set: {
+          //     changes: {
+          //       $sortArray: {
+          //         input: '$changes',
+          //         sortBy: { 'fullDocument._change.seq': -1 }
+          //       }
+          //     }
+          //   }
+          // },
+          {
+            $sort: {
+              createdAt: -1
+            }
+          }
+        ])
+      return rs2
+    }
+  }
+}
+
+// TS error bug: https://github.com/GraphQLGuide/apollo-datasource-mongodb/issues/88
+// @ts-expect-error
+export const organizationHistoryDataSource = new OrganizationHistoryDataSource(getChangeLogModel())

--- a/src/utils/inMemoryDB.ts
+++ b/src/utils/inMemoryDB.ts
@@ -1,6 +1,8 @@
 import mongoose, { ConnectOptions } from 'mongoose'
+import { ChangeStream } from 'mongodb'
 import { MongoMemoryReplSet } from 'mongodb-memory-server'
-import { defaultPostConnect } from '../db/index.js'
+import { defaultPostConnect, checkVar } from '../db/index.js'
+import { logger } from '../logger.js'
 
 /**
  * In-memory Mongo replset used for testing.
@@ -8,27 +10,30 @@ import { defaultPostConnect } from '../db/index.js'
  * Need a replset to faciliate transactions.
  */
 const mongod = await MongoMemoryReplSet.create({
-  replSet: { count: 1, storageEngine: 'wiredTiger' }
+  // Stream listener listens on DB denoted by 'MONGO_DBNAME' env var.
+  replSet: { count: 1, storageEngine: 'wiredTiger', dbName: checkVar('MONGO_DBNAME') }
 })
+let stream: ChangeStream
 
 /**
  * Connect to the in-memory database.
  */
 const connect = async (): Promise<void> => {
-  const uri = await mongod.getUri()
-
+  const uri = await mongod.getUri(checkVar('MONGO_DBNAME'))
+  logger.info(`Connecting to database ${uri}`)
   const mongooseOpts: ConnectOptions = {
     autoIndex: false // Create indices using defaultPostConnect instead.
   }
 
   await mongoose.connect(uri, mongooseOpts)
-  await defaultPostConnect()
+  stream = await defaultPostConnect()
 }
 
 /**
  * Drop database, close the connection and stop mongod.
  */
 const close = async (): Promise<void> => {
+  await stream.close()
   await mongoose.connection.dropDatabase()
   await mongoose.connection.close()
   await mongod.stop()


### PR DESCRIPTION
Addresses: https://github.com/orgs/OpenBeta/projects/6/views/1?pane=issue&itemId=25526852

Confirms that the in-memory mongo replset can support our integration tests. We were worried that the stream listeners required to support change histories would not be supported by the in-memory replset. In this PR, we update the integration tests to demonstrate that the stream listeners do capture incoming changes.