### PR TITLE
feat: Aid scale

### DIFF
--- a/src/GradeUtils.ts
+++ b/src/GradeUtils.ts
@@ -44,7 +44,7 @@ export const gradeContextToGradeScales: Partial<Record<GradeContexts, ClimbGrade
     tr: GradeScales.EWBANK,
     alpine: GradeScales.YDS,
     mixed: GradeScales.YDS,
-    aid: GradeScales.YDS,
+    aid: GradeScales.AID,
     snow: GradeScales.YDS, // is this the same as alpine?
     ice: GradeScales.WI
   },
@@ -55,7 +55,7 @@ export const gradeContextToGradeScales: Partial<Record<GradeContexts, ClimbGrade
     tr: GradeScales.YDS,
     alpine: GradeScales.YDS,
     mixed: GradeScales.YDS,
-    aid: GradeScales.YDS,
+    aid: GradeScales.AID,
     snow: GradeScales.YDS, // is this the same as alpine?
     ice: GradeScales.WI
   },
@@ -66,7 +66,7 @@ export const gradeContextToGradeScales: Partial<Record<GradeContexts, ClimbGrade
     tr: GradeScales.FRENCH,
     alpine: GradeScales.FRENCH,
     mixed: GradeScales.FRENCH,
-    aid: GradeScales.FRENCH,
+    aid: GradeScales.AID,
     snow: GradeScales.FRENCH, // is this the same as alpine?
     ice: GradeScales.WI
   },
@@ -77,7 +77,7 @@ export const gradeContextToGradeScales: Partial<Record<GradeContexts, ClimbGrade
     tr: GradeScales.FRENCH,
     alpine: GradeScales.FRENCH,
     mixed: GradeScales.FRENCH,
-    aid: GradeScales.FRENCH,
+    aid: GradeScales.AID,
     snow: GradeScales.FRENCH, // SA does not have a whole lot of snow
     ice: GradeScales.WI
   }

--- a/src/__tests__/gradeUtils.ts
+++ b/src/__tests__/gradeUtils.ts
@@ -47,6 +47,21 @@ describe('Test grade utilities', () => {
       yds: '5.9'
     })
 
+    actual = createGradeObject('5.10a', sanitizeDisciplines({ trad: true }), context)
+    expect(actual).toEqual({
+      yds: '5.10a'
+    })
+
+    actual = createGradeObject('A1', sanitizeDisciplines({ aid: true }), context)
+    expect(actual).toEqual({
+      aid: 'A1'
+    })
+
+    actual = createGradeObject('C2+', sanitizeDisciplines({ aid: true }), context)
+    expect(actual).toEqual({
+      aid: 'C2+'
+    })
+
     actual = createGradeObject('V4', sanitizeDisciplines({ bouldering: true }), context)
     expect(actual).toEqual({
       vscale: 'V4'
@@ -85,6 +100,16 @@ describe('Test grade utilities', () => {
       ewbank: '5'
     })
 
+    actual = createGradeObject('A2', sanitizeDisciplines({ aid: true }), context)
+    expect(actual).toEqual({
+      aid: 'A2'
+    })
+
+    actual = createGradeObject('C3+', sanitizeDisciplines({ aid: true }), context)
+    expect(actual).toEqual({
+      aid: 'C3+'
+    })
+
     actual = createGradeObject('v11', sanitizeDisciplines({ bouldering: true }), context)
     expect(actual).toEqual({
       vscale: 'v11'
@@ -107,6 +132,16 @@ describe('Test grade utilities', () => {
     let actual = createGradeObject('5a', sanitizeDisciplines({ sport: true }), context)
     expect(actual).toEqual({
       french: '5a'
+    })
+
+    actual = createGradeObject('A2', sanitizeDisciplines({ aid: true }), context)
+    expect(actual).toEqual({
+      aid: 'A2'
+    })
+
+    actual = createGradeObject('C1', sanitizeDisciplines({ aid: true }), context)
+    expect(actual).toEqual({
+      aid: 'C1'
     })
 
     actual = createGradeObject('7c', sanitizeDisciplines({ bouldering: true }), context)

--- a/src/model/__tests__/MutableClimbDataSource.ts
+++ b/src/model/__tests__/MutableClimbDataSource.ts
@@ -50,6 +50,12 @@ describe('Climb CRUD', () => {
       disciplines: {
         ice: true
       }
+    },
+    {
+      name: 'Cool aid one',
+      disciplines: {
+        aid: true
+      }
     }
   ]
 
@@ -59,6 +65,15 @@ describe('Climb CRUD', () => {
       sport: true
     },
     description: 'A local testpiece'
+  }
+
+  const newAidRoute: ClimbChangeInputType = {
+    name: 'Gnarly Aid',
+    disciplines: {
+      aid: true
+    },
+    description: 'certain death',
+    grade: 'A0'
   }
 
   const newBoulderProblem1: ClimbChangeInputType = {
@@ -265,7 +280,8 @@ describe('Climb CRUD', () => {
         { ...newSportClimb1, grade: '17' }, // good sport grade
         { ...newSportClimb2, grade: '29/30', disciplines: { trad: true } }, // good trad and slash grade
         { ...newSportClimb2, grade: '5.9' }, // bad AU context grade
-        { ...newIceRoute, grade: 'WI4+' } // good WI AU context grade
+        { ...newIceRoute, grade: 'WI4+' }, // good WI AU context grade
+        { ...newAidRoute, grade: 'A0' } // good aid grade
       ]
 
       const newIDs = await climbs.addOrUpdateClimbs(
@@ -293,6 +309,12 @@ describe('Climb CRUD', () => {
       expect(climb4?.type.trad).toBe(false)
       expect(climb4?.type.bouldering).toBe(false)
       expect(climb4?.type.ice).toBe(true)
+
+      const climb5 = await climbs.findOneClimbByMUUID(muid.from(newIDs[4]))
+      expect(climb5?.grades).toEqual({ aid: 'A0' })
+      expect(climb5?.type.sport).toBe(false)
+      expect(climb5?.type.trad).toBe(false)
+      expect(climb5?.type.aid).toBe(true)
     }
 
     {


### PR DESCRIPTION
Change grade context definitions not to use YDS for aid routes.


depends on 
- [x] https://github.com/OpenBeta/sandbag/pull/96
- [x] bump minimum sandbag version here