### PR TITLE
All fields accessible during addOrganization

### DIFF
--- a/src/__tests__/integration.ts
+++ b/src/__tests__/integration.ts
@@ -230,28 +230,32 @@ describe('graphql server', () => {
     let charlieOrg: OrganizationType
 
     beforeEach(async () => {
-      let emptyOrg = await organizations.addOrganization(user, 'Alpha Club', OrgType.localClimbingOrganization)
       let document: any = {
+        displayName: 'Alpha Club',
         email: 'admin@alpha.com',
         associatedAreaIds: [ca.metadata.area_id, wa.metadata.area_id]
       }
-      alphaOrg = await organizations.updateOrganization(user, emptyOrg.orgId, document)
+      alphaOrg = await organizations.addOrganization(user, OrgType.localClimbingOrganization, document)
         .then((res: OrganizationType | null) => {
           if (res === null) throw new Error('Failure mocking organization.')
           return res
         })
 
-      emptyOrg = await organizations.addOrganization(user, 'Beta Club', OrgType.localClimbingOrganization)
-      document = { email: 'admin@beta.com' }
-      betaOrg = await organizations.updateOrganization(user, emptyOrg.orgId, document)
+      document = {
+        displayName: 'Beta Club',
+        email: 'admin@beta.com'
+      }
+      betaOrg = await organizations.addOrganization(user, OrgType.localClimbingOrganization, document)
         .then((res: OrganizationType | null) => {
           if (res === null) throw new Error('Failure mocking organization.')
           return res
         })
 
-      emptyOrg = await organizations.addOrganization(user, 'Charlie Beta Club', OrgType.localClimbingOrganization)
-      document = { description: 'We are an offshoot of the beta club.\nSee our website for more details.' }
-      charlieOrg = await organizations.updateOrganization(user, emptyOrg.orgId, document)
+      document = {
+        displayName: 'Charlie Beta Club',
+        description: 'We are an offshoot of the beta club.\nSee our website for more details.'
+      }
+      charlieOrg = await organizations.addOrganization(user, OrgType.localClimbingOrganization, document)
         .then((res: OrganizationType | null) => {
           if (res === null) throw new Error('Failure mocking organization.')
           return res

--- a/src/graphql/organization/OrganizationMutations.ts
+++ b/src/graphql/organization/OrganizationMutations.ts
@@ -5,12 +5,13 @@ const OrganizationMutations = {
 
   addOrganization: async (_, { input }, { dataSources, user }: ContextWithAuth): Promise<OrganizationType | null> => {
     const { organizations } = dataSources
-    const { displayName, orgType } = input
 
     // permission middleware shouldn't send undefined uuid
     if (user?.uuid == null) throw new Error('Missing user uuid')
+    if (input?.orgType == null) throw new Error('Missing orgType')
+    if (input?.displayName == null) throw new Error('Missing displayName')
 
-    return await organizations.addOrganization(user.uuid, displayName, orgType)
+    return await organizations.addOrganization(user.uuid, input.orgType, input)
   },
 
   updateOrganization: async (_, { input }, { dataSources, user }: ContextWithAuth): Promise<OrganizationType | null> => {

--- a/src/graphql/schema/OrganizationEdit.gql
+++ b/src/graphql/schema/OrganizationEdit.gql
@@ -13,6 +13,13 @@ type Mutation {
 input AddOrganizationInput {
   displayName: String!
   orgType: String!
+  associatedAreaIds: [MUUID]
+  excludedAreaIds: [MUUID]
+  website: String
+  email: String
+  donationLink: String
+  instagramLink: String
+  description: String
 }
 
 input OrganizationEditableFieldsInput {


### PR DESCRIPTION
Previously, `addOrganization` would only add a shell object containing `displayName`, and `orgType`. We would have to make a separate `updateOrganization` call later on to add `website`, `instagramLink` and others.

This change enables us to supply `website`, and other fields immediately in the `addOrganization` call, thus reducing one API call.

This PR completes the second outstanding task required for https://github.com/OpenBeta/open-tacos/pull/788