### PR TITLE
feat: Ice context

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "@babel/runtime": "^7.17.2",
     "@google-cloud/storage": "^6.9.5",
     "@graphql-tools/schema": "^8.3.1",
-    "@openbeta/sandbag": "^0.0.37",
+    "@openbeta/sandbag": "^0.0.45",
     "@turf/area": "^6.5.0",
     "@turf/bbox": "^6.5.0",
     "@turf/bbox-polygon": "^6.5.0",

--- a/src/GradeUtils.ts
+++ b/src/GradeUtils.ts
@@ -46,7 +46,7 @@ export const gradeContextToGradeScales: Partial<Record<GradeContexts, ClimbGrade
     mixed: GradeScales.YDS,
     aid: GradeScales.YDS,
     snow: GradeScales.YDS, // is this the same as alpine?
-    ice: GradeScales.YDS // is this the same as alpine?
+    ice: GradeScales.WI
   },
   [GradeContexts.US]: {
     trad: GradeScales.YDS,
@@ -57,7 +57,7 @@ export const gradeContextToGradeScales: Partial<Record<GradeContexts, ClimbGrade
     mixed: GradeScales.YDS,
     aid: GradeScales.YDS,
     snow: GradeScales.YDS, // is this the same as alpine?
-    ice: GradeScales.YDS // is this the same as alpine?
+    ice: GradeScales.WI
   },
   [GradeContexts.FR]: {
     trad: GradeScales.FRENCH,
@@ -68,7 +68,7 @@ export const gradeContextToGradeScales: Partial<Record<GradeContexts, ClimbGrade
     mixed: GradeScales.FRENCH,
     aid: GradeScales.FRENCH,
     snow: GradeScales.FRENCH, // is this the same as alpine?
-    ice: GradeScales.FRENCH // is this the same as alpine?
+    ice: GradeScales.WI
   },
   [GradeContexts.SA]: {
     trad: GradeScales.FRENCH,
@@ -79,7 +79,7 @@ export const gradeContextToGradeScales: Partial<Record<GradeContexts, ClimbGrade
     mixed: GradeScales.FRENCH,
     aid: GradeScales.FRENCH,
     snow: GradeScales.FRENCH, // SA does not have a whole lot of snow
-    ice: GradeScales.FRENCH // SA does not have a whole lot of ice
+    ice: GradeScales.WI
   }
 }
 

--- a/src/__tests__/gradeUtils.ts
+++ b/src/__tests__/gradeUtils.ts
@@ -52,6 +52,11 @@ describe('Test grade utilities', () => {
       vscale: 'V4'
     })
 
+    actual = createGradeObject('WI2', sanitizeDisciplines({ ice: true }), context)
+    expect(actual).toEqual({
+      wi: 'WI2'
+    })
+
     // mismatch input and discipline
     actual = createGradeObject('V4', sanitizeDisciplines({ trad: true }), context)
     expect(actual).toBeUndefined()
@@ -59,6 +64,16 @@ describe('Test grade utilities', () => {
     // invalid input
     actual = createGradeObject('6a', sanitizeDisciplines({ trad: true }), context)
     expect(actual).toBeUndefined()
+  })
+
+  it.failing('can alpine ice grades to climbs with discipline ice', () => {
+    const context = gradeContextToGradeScales.US
+    if (context == null) fail('Bad grade context.  Should not happen.')
+
+    const actual = createGradeObject('AI2', sanitizeDisciplines({ ice: true }), context)
+    expect(actual).toEqual({
+      ai: 'AI2'
+    })
   })
 
   it('creates grade object correctly in AU context', () => {
@@ -73,6 +88,11 @@ describe('Test grade utilities', () => {
     actual = createGradeObject('v11', sanitizeDisciplines({ bouldering: true }), context)
     expect(actual).toEqual({
       vscale: 'v11'
+    })
+
+    actual = createGradeObject('WI4+', sanitizeDisciplines({ ice: true }), context)
+    expect(actual).toEqual({
+      wi: 'WI4+'
     })
 
     // Invalid input
@@ -92,6 +112,11 @@ describe('Test grade utilities', () => {
     actual = createGradeObject('7c', sanitizeDisciplines({ bouldering: true }), context)
     expect(actual).toEqual({
       font: '7c'
+    })
+
+    actual = createGradeObject('WI6', sanitizeDisciplines({ ice: true }), context)
+    expect(actual).toEqual({
+      wi: 'WI6'
     })
 
     // Invalid input

--- a/yarn.lock
+++ b/yarn.lock
@@ -1579,10 +1579,10 @@
     "@nodelib/fs.scandir" "2.1.5"
     fastq "^1.6.0"
 
-"@openbeta/sandbag@^0.0.37":
-  version "0.0.37"
-  resolved "https://registry.yarnpkg.com/@openbeta/sandbag/-/sandbag-0.0.37.tgz#59befbb2bace586be19c0a3c6d9f8046c05fa05e"
-  integrity sha512-oeCqXAZkvgHkUOHZefhZyftxsarcdHUtS2oEttIACCRpZ/Vs2hAmyXIn1Yg7dxnQEKbJ3TtVD4trUmNoJSolag==
+"@openbeta/sandbag@^0.0.45":
+  version "0.0.45"
+  resolved "https://registry.yarnpkg.com/@openbeta/sandbag/-/sandbag-0.0.45.tgz#b6230ddf63f265b91d0a0359a2f87c5359dded74"
+  integrity sha512-8s2YFeUBU3lK2EzQIZSsf/apEIaxhtHJNfWWDmtjIE7/wlgqm84BSX72wur1FGrqcI9o3P1dkZmevHnu0ItGZQ==
 
 "@panva/asn1.js@^1.0.0":
   version "1.0.0"


### PR DESCRIPTION
This adds basic support for ice climbs with the WI grade scales.

This currently assumes that all contexts use only Winter Ice grades rather than a mix of Alpine Ice and Winter Ice.  This is not the case; the grade scale depends on the local climate.

To enable AI grades in future, the ice grades allowed in most contexts should be an array: `[GradeScales.AI, GradeScales.WI]`.


----

Depends on 

- [x] bump version of sandbag
- [x] update version requirement here