### PR TITLE
Bradley/dev mode credentials

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -57,6 +57,18 @@
             ]
         },
         {
+          "type": "node",
+          "request": "launch",
+          "name": "Launch API Server (serve-dev)",
+          "skipFiles": ["<node_internals>/**"],
+          "program": "${workspaceFolder}/src/main.ts",
+          "preLaunchTask": "tsc: build - tsconfig.json",
+          "outFiles": ["${workspaceFolder}/build/**/*.js"],
+          "runtimeExecutable": "yarn",
+          "runtimeArgs": ["run", "serve-dev"],
+          "console": "integratedTerminal"
+        },
+        {
             "name": "Debug Jest Tests",
             "type": "node",
             "request": "launch",

--- a/package.json
+++ b/package.json
@@ -63,6 +63,7 @@
     "build-release": "tsc  -p tsconfig.release.json",
     "clean": "tsc -b --clean && rm -rf build/*",
     "serve": "yarn build && node --experimental-json-modules build/main.js",
+    "serve-dev": "NODE_ENV=development yarn serve",
     "refresh-db": "./refresh-db.sh",
     "seed-usa": "yarn build && node build/db/import/usa/USADay0Seed.js",
     "add-countries": "yarn build && node build/db/utils/jobs/AddCountriesJob.js",

--- a/package.json
+++ b/package.json
@@ -63,7 +63,7 @@
     "build-release": "tsc  -p tsconfig.release.json",
     "clean": "tsc -b --clean && rm -rf build/*",
     "serve": "yarn build && node --experimental-json-modules build/main.js",
-    "serve-dev": "NODE_ENV=development yarn serve",
+    "serve-dev": "GOD_MODE=true yarn serve",
     "refresh-db": "./refresh-db.sh",
     "seed-usa": "yarn build && node build/db/import/usa/USADay0Seed.js",
     "add-countries": "yarn build && node build/db/utils/jobs/AddCountriesJob.js",

--- a/src/auth/middleware.ts
+++ b/src/auth/middleware.ts
@@ -23,7 +23,7 @@ export const createContext = (() => {
     }
 
     if (process.env.GOD_MODE === 'true' && (user.uuid == null)) {
-      user.roles = ['user_admin','org_admin', 'editor']
+      user.roles = ['user_admin', 'org_admin', 'editor']
       user.uuid = testUUID
     } else {
       const authHeader = String(headers?.authorization ?? '')

--- a/src/auth/middleware.ts
+++ b/src/auth/middleware.ts
@@ -1,4 +1,5 @@
 import muid, { MUUID } from 'uuid-mongodb'
+import { logger } from '../logger.js'
 import { AuthUserType } from '../types.js'
 import { verifyJWT } from './util.js'
 
@@ -8,9 +9,9 @@ import { verifyJWT } from './util.js'
 export const createContext = (() => {
   let testUUID: MUUID
 
-  if (process.env.NODE_ENV === 'development') {
+  if (process.env.GOD_MODE === 'true') {
     testUUID = muid.v4()
-    console.log(`The user.uuid for this session is: ${testUUID.toString()}`)
+    logger.info(`The user.uuid for this session is: ${testUUID.toString()}`)
   }
 
   return async ({ req }): Promise<any> => {
@@ -21,8 +22,8 @@ export const createContext = (() => {
       uuid: undefined
     }
 
-    if (process.env.NODE_ENV === 'development' && (user.uuid == null)) {
-      user.roles = ['admin', 'editor']
+    if (process.env.GOD_MODE === 'true' && (user.uuid == null)) {
+      user.roles = ['user_admin','org_admin', 'editor']
       user.uuid = testUUID
     } else {
       const authHeader = String(headers?.authorization ?? '')


### PR DESCRIPTION
**What?**
Create `serve-dev` command which automatically authenticates the user and gives them certain permissions, as described in [this issue](https://github.com/OpenBeta/openbeta-graphql/issues/267).

**How?**
The issue linked above described the process pretty well, but notice that `createContext` now creates a closure so that seperate requests will not keep creating new user id's. I also created a launch config object so we can run the new `serve-dev` command using a debugger.

**Validation?**
I used the `serve-dev` command to add areas to the db in the graphql playground. I was shaky on how to get the necessary uuid's (for specifying which specific area I wanted to delte, fetch, etc), so it would probably be a good idea for someone more familiar with the API to run the new command, then exercise other API endpoints, just so we can validate it with more code paths. Alternatively, maybe someone more familiar with using the API and I can chat on discord and I'll run additional validation myself.

**Tests?**
I haven't implemented any tests yet :(
If anyone thinks I should, let me know and I'll get on it. 