### PR TITLE
Add organizations field in area resolver

### DIFF
--- a/src/__tests__/areas.ts
+++ b/src/__tests__/areas.ts
@@ -1,0 +1,104 @@
+import { ApolloServer } from 'apollo-server'
+import muuid from 'uuid-mongodb'
+import { jest } from '@jest/globals'
+import MutableAreaDataSource, { createInstance as createAreaInstance } from '../model/MutableAreaDataSource.js'
+import MutableOrganizationDataSource, { createInstance as createOrgInstance } from '../model/MutableOrganizationDataSource.js'
+import { AreaType } from '../db/AreaTypes.js'
+import { OrgType, OrganizationType, OrganizationEditableFieldsType } from '../db/OrganizationTypes.js'
+import { queryAPI, setUpServer } from '../utils/testUtils.js'
+import { muuidToString } from '../utils/helpers.js'
+
+jest.setTimeout(60000)
+
+describe('areas API', () => {
+  let server: ApolloServer
+  let user: muuid.MUUID
+  let userUuid: string
+  let inMemoryDB
+
+  // Mongoose models for mocking pre-existing state.
+  let areas: MutableAreaDataSource
+  let organizations: MutableOrganizationDataSource
+  let usa: AreaType
+  let ca: AreaType
+  let wa: AreaType
+
+  beforeAll(async () => {
+    ({ server, inMemoryDB } = await setUpServer())
+    // Auth0 serializes uuids in "relaxed" mode, resulting in this hex string format
+    // "59f1d95a-627d-4b8c-91b9-389c7424cb54" instead of base64 "WfHZWmJ9S4yRuTicdCTLVA==".
+    user = muuid.mode('relaxed').v4()
+    userUuid = muuidToString(user)
+  })
+
+  beforeEach(async () => {
+    await inMemoryDB.clear()
+    areas = createAreaInstance()
+    organizations = createOrgInstance()
+    usa = await areas.addCountry('usa')
+    ca = await areas.addArea(user, 'CA', usa.metadata.area_id)
+    wa = await areas.addArea(user, 'WA', usa.metadata.area_id)
+  })
+
+  afterAll(async () => {
+    await server.stop()
+    await inMemoryDB.close()
+  })
+
+  describe('queries', () => {
+    const areaQuery = `
+      query area($input: ID) {
+        area(uuid: $input) {
+          uuid
+          organizations {
+            orgId
+          }
+        }
+      }
+    `
+    let alphaFields: OrganizationEditableFieldsType
+    let alphaOrg: OrganizationType
+
+    beforeEach(async () => {
+      alphaFields = {
+        displayName: 'USA without CA Org',
+        associatedAreaIds: [usa.metadata.area_id],
+        excludedAreaIds: [ca.metadata.area_id]
+      }
+      alphaOrg = await organizations.addOrganization(user, OrgType.localClimbingOrganization, alphaFields)
+        .then((res: OrganizationType | null) => {
+          if (res === null) throw new Error('Failure mocking organization.')
+          return res
+        })
+    })
+
+    it('retrieves an area and lists associated organizations', async () => {
+      const response = await queryAPI({
+        query: areaQuery,
+        operationName: 'area',
+        variables: { input: wa.metadata.area_id },
+        userUuid
+      })
+      expect(response.statusCode).toBe(200)
+      const areaResult = response.body.data.area
+      expect(areaResult.uuid).toBe(muuidToString(wa.metadata.area_id))
+      expect(areaResult.organizations.length).toBe(1)
+      expect(areaResult.organizations[0].orgId).toBe(muuidToString(alphaOrg.orgId))
+    })
+
+    it('retrieves an area omitting organizations that exclude it', async () => {
+      const response = await queryAPI({
+        query: areaQuery,
+        operationName: 'area',
+        variables: { input: ca.metadata.area_id },
+        userUuid
+      })
+      expect(response.statusCode).toBe(200)
+      const areaResult = response.body.data.area
+      expect(areaResult.uuid).toBe(muuidToString(ca.metadata.area_id))
+      // Even though alphaOrg associates with ca's parent, usa, it excludes
+      // ca and so should not be listed.
+      expect(areaResult.organizations.length).toBe(0)
+    })
+  })
+})

--- a/src/__tests__/organizations.ts
+++ b/src/__tests__/organizations.ts
@@ -236,7 +236,8 @@ describe('organizations API', () => {
 
       gammaFields = {
         displayName: 'Delta Gamma OpenBeta Club',
-        description: 'We are an offshoot of the delta club.\nSee our website for more details.'
+        description: 'We are an offshoot of the delta club.\nSee our website for more details.',
+        excludedAreaIds: [wa.metadata.area_id]
       }
       gammaOrg = await organizations.addOrganization(user, OrgType.localClimbingOrganization, gammaFields)
         .then((res: OrganizationType | null) => {
@@ -316,6 +317,19 @@ describe('organizations API', () => {
       const dataResult = response.body.data.organizations
       expect(dataResult.length).toBe(1)
       expect(dataResult[0].orgId).toBe(muuidToString(alphaOrg.orgId))
+    })
+
+    it('excludes organizations using an excludedAreaIds filter', async () => {
+      const response = await queryAPI({
+        query: organizationsQuery,
+        operationName: 'organizations',
+        variables: { filter: { excludedAreaIds: { excludes: [muuidToString(wa.metadata.area_id)] } } },
+        userUuid
+      })
+      expect(response.statusCode).toBe(200)
+      const dataResult = response.body.data.organizations
+      expect(dataResult.length).toBe(2)
+      expect(dataResult.map((o: OrganizationType) => o.orgId).includes(muuidToString(gammaOrg.orgId))).toBeFalsy()
     })
   })
 })

--- a/src/graphql/organization/OrganizationQueries.ts
+++ b/src/graphql/organization/OrganizationQueries.ts
@@ -23,7 +23,7 @@ const OrganizationQueries = {
     if (sort != null) {
       return await filtered.collation({ locale: 'en' }).sort(sort).limit(limit).toArray()
     } else {
-      return await filtered.collation({ locale: 'en' }).limit(limit).toArray()
+      return await filtered.limit(limit).toArray()
     }
   }
 }

--- a/src/graphql/resolvers.ts
+++ b/src/graphql/resolvers.ts
@@ -257,13 +257,13 @@ const resolvers = {
     organizations: async (node: AreaType, args: any, { dataSources }: Context) => {
       const { organizations } = dataSources
       const areaIdsToSearch = [node.metadata.area_id, ...node.ancestors.split(',').map(s => muid.from(s))]
-      const associatedOrgs = await (await organizations.findOrganizationsByFilter({
+      const associatedOrgsCursor = await organizations.findOrganizationsByFilter({
         associatedAreaIds: { includes: areaIdsToSearch },
         // Remove organizations that explicitly request not to be associated with this area.
         // This specification has to be exact, we don't exclude the entire subtree, only the node itself.
         excludedAreaIds: { excludes: [node.metadata.area_id] }
-      })).toArray()
-      return associatedOrgs
+      })
+      return await associatedOrgsCursor.toArray()
     }
   },
 

--- a/src/graphql/resolvers.ts
+++ b/src/graphql/resolvers.ts
@@ -7,7 +7,7 @@ import { DocumentNode } from 'graphql'
 
 import { CommonResolvers, CommonTypeDef } from './common/index.js'
 import { HistoryQueries, HistoryFieldResolvers } from '../graphql/history/index.js'
-import { QueryByIdType, GQLFilter, Sort } from '../types'
+import { QueryByIdType, GQLFilter, Sort, Context } from '../types'
 import { AreaType, CountByDisciplineType } from '../db/AreaTypes.js'
 import { ClimbGQLQueryType, ClimbType } from '../db/ClimbTypes.js'
 import AreaDataSource from '../model/AreaDataSource.js'
@@ -251,7 +251,20 @@ const resolvers = {
       const { media }: { media: MediaDataSource } = dataSources
       return await media.findMediaByAreaId(node.metadata.area_id, node.ancestors)
     },
-    authorMetadata: getAuthorMetadataFromBaseNode
+
+    authorMetadata: getAuthorMetadataFromBaseNode,
+
+    organizations: async (node: AreaType, args: any, { dataSources }: Context) => {
+      const { organizations } = dataSources
+      const areaIdsToSearch = [node.metadata.area_id, ...node.ancestors.split(',').map(s => muid.from(s))]
+      const associatedOrgs = await (await organizations.findOrganizationsByFilter({
+        associatedAreaIds: { includes: areaIdsToSearch },
+        // Remove organizations that explicitly request not to be associated with this area.
+        // This specification has to be exact, we don't exclude the entire subtree, only the node itself.
+        excludedAreaIds: { excludes: [node.metadata.area_id] }
+      })).toArray()
+      return associatedOrgs
+    }
   },
 
   CountByDisciplineType: {

--- a/src/graphql/schema/Area.gql
+++ b/src/graphql/schema/Area.gql
@@ -68,6 +68,8 @@ type Area {
   media: [MediaWithTags]
   "Metadata about creation & update of this area"
   authorMetadata: AuthorMetadata!
+  "Organizations associated with this area or its parent areas"
+  organizations: [Organization]
 }
 
 type AreaMetadata {

--- a/src/graphql/schema/Organization.gql
+++ b/src/graphql/schema/Organization.gql
@@ -46,6 +46,7 @@ input OrgSort {
 input OrgFilter {
   displayName: DisplayNameFilter
   associatedAreaIds: AssociatedAreaIdsFilter
+  excludedAreaIds: ExcludedAreaIdsFilter
 }
 
 input DisplayNameFilter {
@@ -53,6 +54,12 @@ input DisplayNameFilter {
   exactMatch: Boolean
 }
 
+"Filter for organizations that are associated with an area."
 input AssociatedAreaIdsFilter {
   includes: [MUUID]
+}
+
+"Filter for organizations that have not excluded themselves from an area."
+input ExcludedAreaIdsFilter {
+  excludes: [MUUID]
 }

--- a/src/model/OrganizationDataSource.ts
+++ b/src/model/OrganizationDataSource.ts
@@ -4,7 +4,7 @@ import type { FindCursor, WithId } from 'mongodb'
 import muuid from 'uuid-mongodb'
 
 import { getOrganizationModel } from '../db/index.js'
-import { AssociatedAreaIdsFilterParams, DisplayNameFilterParams, OrganizationGQLFilter } from '../types'
+import { AssociatedAreaIdsFilterParams, DisplayNameFilterParams, ExcludedAreaIdsFilterParams, OrganizationGQLFilter } from '../types'
 import { OrganizationType } from '../db/OrganizationTypes.js'
 import { muuidToString } from '../utils/helpers.js'
 
@@ -25,6 +25,11 @@ export default class OrganizationDataSource extends MongoDataSource<Organization
           case 'associatedAreaIds': {
             const associatedAreaIdFilter = (filter as AssociatedAreaIdsFilterParams)
             acc.associatedAreaIds = { $in: associatedAreaIdFilter.includes }
+            break
+          }
+          case 'excludedAreaIds': {
+            const excludedAreaIdFilter = (filter as ExcludedAreaIdsFilterParams)
+            acc.excludedAreaIds = { $not: { $in: excludedAreaIdFilter.excludes } }
             break
           }
           default:

--- a/src/model/OrganizationDataSource.ts
+++ b/src/model/OrganizationDataSource.ts
@@ -13,7 +13,7 @@ export default class OrganizationDataSource extends MongoDataSource<Organization
 
   async findOrganizationsByFilter (filters?: OrganizationGQLFilter): Promise<FindCursor<WithId<OrganizationType>>> {
     let mongoFilter: any = {}
-    if (filters !== undefined) {
+    if (filters != null) {
       mongoFilter = Object.entries(filters).reduce<Filter<OrganizationType>>((acc, [key, filter]): Filter<OrganizationType> => {
         switch (key) {
           case 'displayName': {

--- a/src/model/__tests__/MutableOrganizationDataSource.ts
+++ b/src/model/__tests__/MutableOrganizationDataSource.ts
@@ -82,7 +82,8 @@ describe('Organization', () => {
   it('should retrieve documents based on displayName', async () => {
     const newOrg = await organizations.addOrganization(testUser, OrgType.localClimbingOrganization, fullOrg)
     // Match should be case-insensitive.
-    const displayNameSearchRes = await (await organizations.findOrganizationsByFilter({ displayName: { match: 'openbeta', exactMatch: false } })).toArray()
+    const displayNameSearchCursor = await organizations.findOrganizationsByFilter({ displayName: { match: 'openbeta', exactMatch: false } })
+    const displayNameSearchRes = await displayNameSearchCursor.toArray()
     expect(displayNameSearchRes).toHaveLength(1)
     expect(displayNameSearchRes[0]._id).toEqual(newOrg._id)
   })
@@ -93,7 +94,8 @@ describe('Organization', () => {
       associatedAreaIds: [ca.metadata.area_id, wa.metadata.area_id]
     }
     await organizations.updateOrganization(testUser, newOrg.orgId, document)
-    const areaIdSearchRes = await (await organizations.findOrganizationsByFilter({ associatedAreaIds: { includes: [ca.metadata.area_id] } })).toArray()
+    const areaIdSearchCursor = await organizations.findOrganizationsByFilter({ associatedAreaIds: { includes: [ca.metadata.area_id] } })
+    const areaIdSearchRes = await areaIdSearchCursor.toArray()
     expect(areaIdSearchRes).toHaveLength(1)
     expect(areaIdSearchRes[0]._id).toEqual(newOrg._id)
   })

--- a/src/types.ts
+++ b/src/types.ts
@@ -55,9 +55,13 @@ export interface AssociatedAreaIdsFilterParams {
   includes: MUUID[]
 }
 
-type OrganizationFilterable = 'displayName' | 'associatedAreaIds'
+export interface ExcludedAreaIdsFilterParams {
+  excludes: MUUID[]
+}
 
-type OrganizationFilterParams = DisplayNameFilterParams | AssociatedAreaIdsFilterParams
+type OrganizationFilterable = 'displayName' | 'associatedAreaIds' | 'excludedAreaIds'
+
+type OrganizationFilterParams = DisplayNameFilterParams | AssociatedAreaIdsFilterParams | ExcludedAreaIdsFilterParams
 export type OrganizationGQLFilter = Partial<Record<OrganizationFilterable, OrganizationFilterParams>>
 
 export type LNGLAT = [number, number]


### PR DESCRIPTION
Enables us to retrieve organizations associated with an area in a single area query. Eg:
```
query area($input: ID) {
  area(uuid: $input) {
    uuid
    organizations {
      ...
    }
  }
}
```

Under the hood it does two things in the area resolver:
1. Finds organizations with an `associatedAreaId` that is the area requested or one of its parents. (I.e. Associating with an area automatically associates with all of its subareas.
2. Remove organizations with an `excludedAreaId` that is the area requested. (I.e. unlike associating, excluding does not exclude the entire subtree. Only the exact area listed.)