### PR TITLE
updateSortingOrder for areas allows re-sorting in-place

### DIFF
--- a/src/model/MutableAreaDataSource.ts
+++ b/src/model/MutableAreaDataSource.ts
@@ -368,9 +368,25 @@ export default class MutableAreaDataSource extends AreaDataSource {
     const doUpdate = async (session: ClientSession, user: MUUID, input: UpdateSortingOrderType[]): Promise<string[]> => {
       const opType = OperationType.orderAreas
       const change = await changelogDataSource.create(session, user, opType)
+      const updates: any[] = []
+      let expectedOpCount = input.length
 
-      const bulkData = input.map(({ areaId, leftRightIndex }, index) => (
-        {
+      // Clear existing indices so we can re-order without running into duplicate key errors.
+      if (input.some(i => i.leftRightIndex >= 0)) {
+        updates.push({
+          updateMany: {
+            filter: { 'metadata.area_id': { $in: input.map(i => muuid.from(i.areaId)) } },
+            update: {
+              $set: { 'metadata.leftRightIndex': -1 }
+              // Don't record change since this is an intermediate step.
+            }
+          }
+        })
+        expectedOpCount = expectedOpCount * 2
+      }
+
+      input.forEach(({ areaId, leftRightIndex }, index) => {
+        updates.push({
           updateOne: {
             filter: { 'metadata.area_id': muuid.from(areaId) },
             update: {
@@ -387,11 +403,11 @@ export default class MutableAreaDataSource extends AreaDataSource {
             }
           }
         })
-      )
+      })
 
-      const rs = (await this.areaModel.bulkWrite(bulkData, { session })).toJSON()
+      const rs = (await this.areaModel.bulkWrite(updates, { session })).toJSON()
 
-      if (rs.ok === 1 && rs.nMatched === rs.nModified && rs.nMatched === input.length) {
+      if (rs.ok === 1 && rs.nMatched === rs.nModified && rs.nMatched === expectedOpCount) {
         return input.map(item => item.areaId)
       } else {
         throw new Error(`Expect to update ${input.length} areas but found ${rs.nMatched}.`)

--- a/src/model/__tests__/updateAreas.ts
+++ b/src/model/__tests__/updateAreas.ts
@@ -277,13 +277,26 @@ describe('Areas', () => {
         })
       }))
 
+    // Able to overwrite existing leftRightIndices without duplicate key errors
+    const change3: UpdateSortingOrderType = {
+      areaId: a1.metadata.area_id.toUUID().toString(),
+      leftRightIndex: 9
+    }
+    const change4: UpdateSortingOrderType = {
+      areaId: a2.metadata.area_id.toUUID().toString(),
+      leftRightIndex: 10
+    }
+
+    await expect(areas.updateSortingOrder(testUser, [change3, change4])).resolves.toStrictEqual(
+      [a1.metadata.area_id.toUUID().toString(), a2.metadata.area_id.toUUID().toString()])
+
     // Make sure we can't have duplicate leftToRight indices >= 0
     await expect(
-      areas.updateSortingOrder(testUser, [{ ...change1, leftRightIndex: change2.leftRightIndex }]))
+      areas.updateSortingOrder(testUser, [{ ...change3, leftRightIndex: change4.leftRightIndex }]))
       .rejects.toThrowError(/E11000/)
 
     // But we can have duplicate indices < 0 to indicate unsorted
     await areas.updateSortingOrder(testUser,
-      [{ ...change1, leftRightIndex: -1 }, { ...change2, leftRightIndex: -1 }])
+      [{ ...change3, leftRightIndex: -1 }, { ...change4, leftRightIndex: -1 }])
   })
 })


### PR DESCRIPTION
In response to problem noted here: https://github.com/OpenBeta/open-tacos/pull/696#issuecomment-1552148382

> In testing, I'm hitting the duplicate index error for leftRightIndex. I think it's because I'm sending [{areaId: .., leftRightIndex: 0}, {areaId: .., leftRightIndex: 1}, .., {areaId: .., leftRightIndex: <# of childareas -1>}] and when we try to set the leftRightIndex to be 0 for the first item, there is already another entry in the db with leftRightIndex 0, so throws the error even though later on, that item's leftRightIndex will replaced by a different entry. I could reset everything to -1 and then reassign, but it's not that elegant.

In the end, I couldn't find a better way than resetting everything -1. I looked into seeing if Mongo supports deferred constraints to get it to check the uniqueness of `leftRightIndex` only after all the bulk updates are complete. I also looked into whether Mongo could update multiple documents atomically, to avoid the intermediate state where there is a duplicate index. Both didn't work out.