### PR TITLE
Sort area children by leftRightIndex

### DIFF
--- a/src/__tests__/areas.ts
+++ b/src/__tests__/areas.ts
@@ -202,6 +202,7 @@ describe('areas API', () => {
       })
       expect(areaClimbsResponse.statusCode).toBe(200)
       const areaResult = areaClimbsResponse.body.data.area
+      console.log(areaClimbsResponse.body)
       // In leftRightIndex order
       expect(areaResult.climbs[0]).toMatchObject({ name: 'left', metadata: { leftRightIndex: 0 } })
       expect(areaResult.climbs[1]).toMatchObject({ name: 'middle', metadata: { leftRightIndex: 1 } })

--- a/src/__tests__/areas.ts
+++ b/src/__tests__/areas.ts
@@ -202,7 +202,6 @@ describe('areas API', () => {
       })
       expect(areaClimbsResponse.statusCode).toBe(200)
       const areaResult = areaClimbsResponse.body.data.area
-      console.log(areaClimbsResponse.body)
       // In leftRightIndex order
       expect(areaResult.climbs[0]).toMatchObject({ name: 'left', metadata: { leftRightIndex: 0 } })
       expect(areaResult.climbs[1]).toMatchObject({ name: 'middle', metadata: { leftRightIndex: 1 } })

--- a/src/graphql/resolvers.ts
+++ b/src/graphql/resolvers.ts
@@ -20,7 +20,7 @@ import { OrganizationMutations, OrganizationQueries } from './organization/index
 import { TickMutations, TickQueries } from './tick/index.js'
 import { UserQueries, UserMutations, UserResolvers } from './user/index.js'
 import { getAuthorMetadataFromBaseNode } from '../db/utils/index.js'
-import { geojsonPointToLatitude, geojsonPointToLongitude } from '../utils/helpers.js'
+import { compareAreaLeftRightIndex, compareClimbLeftRightIndex, geojsonPointToLatitude, geojsonPointToLongitude } from '../utils/helpers.js'
 
 /**
  * It takes a file name as an argument, reads the file, and returns a GraphQL DocumentNode.
@@ -202,7 +202,7 @@ const resolvers = {
 
     children: async (parent: AreaType, _, { dataSources: { areas } }: Context) => {
       if (parent.children.length > 0) {
-        return await areas.findManyByIds(parent.children)
+        return (await areas.findManyByIds(parent.children)).sort(compareAreaLeftRightIndex)
       }
       return []
     },
@@ -221,11 +221,11 @@ const resolvers = {
       // Test to see if we have actual climb object returned from findOneAreaByUUID()
       const isClimbTypeArray = (x: any[]): x is ClimbType[] => x[0].name != null
       if (isClimbTypeArray(result)) {
-        return result
+        return result.sort(compareClimbLeftRightIndex)
       }
 
       // List of IDs, we need to convert them into actual climbs
-      return await areas.findManyClimbsByUuids(result as MUUID[])
+      return (await areas.findManyClimbsByUuids(result as MUUID[])).sort(compareClimbLeftRightIndex)
     },
 
     metadata: (node: AreaType) => {

--- a/src/graphql/resolvers.ts
+++ b/src/graphql/resolvers.ts
@@ -200,13 +200,6 @@ const resolvers = {
     // New camel case field
     areaName: async (node: AreaType) => node.area_name,
 
-    children: async (parent: AreaType, _, { dataSources: { areas } }: Context) => {
-      if (parent.children.length > 0) {
-        return await areas.findChildren(parent.children)
-      }
-      return []
-    },
-
     aggregate: async (node: AreaType) => {
       return node.aggregate
     },

--- a/src/graphql/resolvers.ts
+++ b/src/graphql/resolvers.ts
@@ -202,7 +202,7 @@ const resolvers = {
 
     children: async (parent: AreaType, _, { dataSources: { areas } }: Context) => {
       if (parent.children.length > 0) {
-        return await areas.findManyByIds(parent.children)
+        return await areas.findChildren(parent.children)
       }
       return []
     },

--- a/src/graphql/resolvers.ts
+++ b/src/graphql/resolvers.ts
@@ -20,7 +20,7 @@ import { OrganizationMutations, OrganizationQueries } from './organization/index
 import { TickMutations, TickQueries } from './tick/index.js'
 import { UserQueries, UserMutations, UserResolvers } from './user/index.js'
 import { getAuthorMetadataFromBaseNode } from '../db/utils/index.js'
-import { compareAreaLeftRightIndex, compareClimbLeftRightIndex, geojsonPointToLatitude, geojsonPointToLongitude } from '../utils/helpers.js'
+import { geojsonPointToLatitude, geojsonPointToLongitude } from '../utils/helpers.js'
 
 /**
  * It takes a file name as an argument, reads the file, and returns a GraphQL DocumentNode.
@@ -202,7 +202,7 @@ const resolvers = {
 
     children: async (parent: AreaType, _, { dataSources: { areas } }: Context) => {
       if (parent.children.length > 0) {
-        return (await areas.findManyByIds(parent.children)).sort(compareAreaLeftRightIndex)
+        return await areas.findManyByIds(parent.children)
       }
       return []
     },
@@ -221,11 +221,11 @@ const resolvers = {
       // Test to see if we have actual climb object returned from findOneAreaByUUID()
       const isClimbTypeArray = (x: any[]): x is ClimbType[] => x[0].name != null
       if (isClimbTypeArray(result)) {
-        return result.sort(compareClimbLeftRightIndex)
+        return result
       }
 
       // List of IDs, we need to convert them into actual climbs
-      return (await areas.findManyClimbsByUuids(result as MUUID[])).sort(compareClimbLeftRightIndex)
+      return await areas.findManyClimbsByUuids(result as MUUID[])
     },
 
     metadata: (node: AreaType) => {

--- a/src/model/AreaDataSource.ts
+++ b/src/model/AreaDataSource.ts
@@ -2,6 +2,7 @@ import { MongoDataSource } from 'apollo-datasource-mongodb'
 import { Filter } from 'mongodb'
 import muuid from 'uuid-mongodb'
 import bboxPolygon from '@turf/bbox-polygon'
+import { Types as mongooseTypes } from 'mongoose'
 
 import { getAreaModel, getMediaModel, getMediaObjectModel } from '../db/index.js'
 import { AreaType } from '../db/AreaTypes'
@@ -111,8 +112,7 @@ export default class AreaDataSource extends MongoDataSource<AreaType> {
         },
         {
           $set: {
-            climbs: { $sortArray: { input: '$climbs', sortBy: { 'metadata.left_right_index': 1 } } },
-            children: { $sortArray: { input: '$children', sortBy: { 'metadata.leftRightIndex': 1 } } }
+            climbs: { $sortArray: { input: '$climbs', sortBy: { 'metadata.left_right_index': 1 } } }
           }
         }
       ])
@@ -121,6 +121,11 @@ export default class AreaDataSource extends MongoDataSource<AreaType> {
       return rs[0]
     }
     throw new Error(`Area ${uuid.toUUID().toString()} not found.`)
+  }
+
+  async findChildren (children: mongooseTypes.ObjectId[]): Promise<AreaType[]> {
+    return await this.areaModel.find().where('_id').in(children)
+      .sort({ 'metadata.leftRightIndex': 1 }).lean()
   }
 
   async findManyClimbsByUuids (uuidList: muuid.MUUID[]): Promise<ClimbType[]> {

--- a/src/model/AreaDataSource.ts
+++ b/src/model/AreaDataSource.ts
@@ -108,6 +108,12 @@ export default class AreaDataSource extends MongoDataSource<AreaType> {
           $set: {
             'climbs.gradeContext': '$gradeContext' // manually set area's grade context to climb
           }
+        },
+        {
+          $set: {
+            climbs: { $sortArray: { input: '$climbs', sortBy: { 'metadata.left_right_index': 1 } } },
+            children: { $sortArray: { input: '$children', sortBy: { 'metadata.leftRightIndex': 1 } } }
+          }
         }
       ])
 

--- a/src/model/AreaDataSource.ts
+++ b/src/model/AreaDataSource.ts
@@ -7,7 +7,7 @@ import { getAreaModel, getMediaModel, getMediaObjectModel } from '../db/index.js
 import { AreaType } from '../db/AreaTypes'
 import { GQLFilter, AreaFilterParams, PathTokenParams, LeafStatusParams, ComparisonFilterParams, StatisticsType, CragsNear, BBoxType } from '../types'
 import { getClimbModel } from '../db/ClimbSchema.js'
-import { ClimbGQLQueryType } from '../db/ClimbTypes.js'
+import { ClimbGQLQueryType, ClimbType } from '../db/ClimbTypes.js'
 import { logger } from '../logger.js'
 
 export default class AreaDataSource extends MongoDataSource<AreaType> {
@@ -117,7 +117,7 @@ export default class AreaDataSource extends MongoDataSource<AreaType> {
     throw new Error(`Area ${uuid.toUUID().toString()} not found.`)
   }
 
-  async findManyClimbsByUuids (uuidList: muuid.MUUID[]): Promise<any> {
+  async findManyClimbsByUuids (uuidList: muuid.MUUID[]): Promise<ClimbType[]> {
     const rs = await this.climbModel.find().where('_id').in(uuidList)
     return rs
   }

--- a/src/utils/helpers.ts
+++ b/src/utils/helpers.ts
@@ -1,5 +1,7 @@
 import { MUUID } from 'uuid-mongodb'
 import { Point } from '@turf/helpers'
+import { AreaType } from '../db/AreaTypes'
+import { ClimbType } from '../db/ClimbTypes'
 
 export const muuidToString = (m: MUUID): string => m.toUUID().toString()
 
@@ -21,3 +23,17 @@ export function exhaustiveCheck (_value: never): never {
 
 export const geojsonPointToLongitude = (point: Point): number => point.coordinates[0]
 export const geojsonPointToLatitude = (point: Point): number => point.coordinates[1]
+
+export function compareAreaLeftRightIndex (a: AreaType, b: AreaType): number {
+  if (a.metadata.leftRightIndex == null || b.metadata.leftRightIndex == null) {
+    return 0 // Preserve order if any element is missing leftRightIndex
+  }
+  return (a.metadata.leftRightIndex - b.metadata.leftRightIndex)
+}
+
+export function compareClimbLeftRightIndex (a: ClimbType, b: ClimbType): number {
+  if (a.metadata.left_right_index == null || b.metadata.left_right_index == null) {
+    return 0 // Preserve order if any element is missing left_right_index
+  }
+  return (a.metadata.left_right_index - b.metadata.left_right_index)
+}

--- a/src/utils/helpers.ts
+++ b/src/utils/helpers.ts
@@ -1,7 +1,5 @@
 import { MUUID } from 'uuid-mongodb'
 import { Point } from '@turf/helpers'
-import { AreaType } from '../db/AreaTypes'
-import { ClimbType } from '../db/ClimbTypes'
 
 export const muuidToString = (m: MUUID): string => m.toUUID().toString()
 
@@ -23,17 +21,3 @@ export function exhaustiveCheck (_value: never): never {
 
 export const geojsonPointToLongitude = (point: Point): number => point.coordinates[0]
 export const geojsonPointToLatitude = (point: Point): number => point.coordinates[1]
-
-export function compareAreaLeftRightIndex (a: AreaType, b: AreaType): number {
-  if (a.metadata.leftRightIndex == null || b.metadata.leftRightIndex == null) {
-    return 0 // Preserve order if any element is missing leftRightIndex
-  }
-  return (a.metadata.leftRightIndex - b.metadata.leftRightIndex)
-}
-
-export function compareClimbLeftRightIndex (a: ClimbType, b: ClimbType): number {
-  if (a.metadata.left_right_index == null || b.metadata.left_right_index == null) {
-    return 0 // Preserve order if any element is missing left_right_index
-  }
-  return (a.metadata.left_right_index - b.metadata.left_right_index)
-}


### PR DESCRIPTION
"Area" graphql objects have a children field containing other areas or climbs. Currently these are unsorted -- we leave the frontend to sort them. But the frontend tends to sort them the same way based on their `leftRightIndex` so why not just return that as a default order returned by the backend? This way frontends won't have to do any sorting.

In response to issue: https://github.com/OpenBeta/openbeta-graphql/issues/294 and first discussed in this PR: https://github.com/OpenBeta/open-tacos/pull/696#discussion_r1199566295