### PR TITLE
chore: new seed-db command

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,11 +84,11 @@ query Example1 {
 docker compose up -d
 ```
 
-2. Seed the development database
+2. Seed your local database with data from staging environment
 
 ```bash
 yarn install
-yarn seed-db   # Create test data from staging database
+yarn seed-db   # May take a few minutes to download a large databse file
 ```
 
 3. Start the GraphQL server

--- a/README.md
+++ b/README.md
@@ -88,7 +88,7 @@ docker compose up -d
 
 ```bash
 yarn install
-yarn seed-db   # May take a few minutes to download a large databse file
+yarn seed-db   # May take a few minutes to download a large database file
 ```
 
 3. Start the GraphQL server

--- a/README.md
+++ b/README.md
@@ -88,8 +88,7 @@ docker compose up -d
 
 ```bash
 yarn install
-yarn refresh-db   # download USA data files locally and import
-yarn update-stats      # update statistics
+yarn seed-db   # Create test data from staging database
 ```
 
 3. Start the GraphQL server
@@ -134,23 +133,6 @@ yarn serve
   ...
   ```
   Why?  See [this issue](https://github.com/microsoft/TypeScript/issues/40878) for an explanation.
-
-- Advanced database commands:
-
-  ```bash
-  # Download & import USA data files.  Also create all other countries.
-  yarn refresh-db full #  Remove 'full' to import only a small dataset
-
-  # Re-import USA from previously downloaded data files (cache dir: ./tmp)
-  # Note: this command will drop and recreate the 'areas' and 'climbs' collection.
-  yarn seed-usa
-
-  # Add all countries (except for USA)
-  yarn add-countries
-
-  # Update area statistics (can be rerun as needed)
-  yarn update-stats
-  ```
 
 - MongoDB playground: https://mongoplayground.net/
 

--- a/package.json
+++ b/package.json
@@ -73,6 +73,7 @@
     "serve": "yarn build && node --experimental-json-modules build/main.js",
     "refresh-db": "./refresh-db.sh",
     "seed-usa": "yarn build && node build/db/import/usa/USADay0Seed.js",
+    "seed-db": "./seed-db.sh",
     "add-countries": "yarn build && node build/db/utils/jobs/AddCountriesJob.js",
     "update-stats": "yarn build && node build/db/utils/jobs/UpdateStatsJob.js",
     "update-climb-search": "tsc ; node build/db/export/Typesense/Typesense.js --climbs",

--- a/seed-db.sh
+++ b/seed-db.sh
@@ -1,0 +1,21 @@
+# This script rebuilds your local database with
+# a copy of OpenBeta staging database.
+#
+#!/bin/bash
+
+FILE_NAME="openbeta-stg-db.tar.gz"
+REMOTE_FILE="https://storage.googleapis.com/openbeta-dev-dbs/$FILE_NAME"
+
+echo "Downloading db file(s)..."
+#wget --content-disposition $REMOTE_FILE
+
+rm -rf ./db-dumps/staging/openbeta
+
+tar xzf $FILE_NAME
+
+. .env
+
+connStr="${MONGO_SCHEME}://${MONGO_INITDB_ROOT_USERNAME}:${MONGO_INITDB_ROOT_PASSWORD}@${MONGO_SERVICE}/${MONGO_DBNAME}?authSource=${MONGO_AUTHDB}&tls=${MONGO_TLS}&replicaSet=${MONGO_REPLICA_SET_NAME}"
+
+mongorestore --uri "$connStr" -d=${MONGO_DBNAME} --gzip --drop ./db-dumps/staging/openbeta
+


### PR DESCRIPTION
Issue #309 

I haven't figured out an automated way to redact emails so for the time being I manually exported the staging db, redacted emails manually and upload the new db file to google storage.