### PR TITLE
Breadcrumbs issue #213 fix

### DIFF
--- a/src/model/MutableAreaDataSource.ts
+++ b/src/model/MutableAreaDataSource.ts
@@ -376,7 +376,7 @@ export default class MutableAreaDataSource extends AreaDataSource {
    * @param newAreaName new area name
    * @param depth tree depth
    */
-  async updatePathTokens (session: ClientSession, changeRecord: ChangeRecordMetadataType, area: AreaDocumnent, newAreaName: string, depth: number = 2): Promise<void> {
+  async updatePathTokens (session: ClientSession, changeRecord: ChangeRecordMetadataType, area: AreaDocumnent, newAreaName: string, depth: number = 1): Promise<void> {
     if (area.pathTokens.length > 1) {
       const newPath = [...area.pathTokens]
       newPath[newPath.length - depth] = newAreaName

--- a/src/model/MutableAreaDataSource.ts
+++ b/src/model/MutableAreaDataSource.ts
@@ -380,7 +380,11 @@ export default class MutableAreaDataSource extends AreaDataSource {
       const newPath = [...area.pathTokens]
       newPath[newPath.length - index] = newAreaName
       area.set({ pathTokens: newPath })
-      await area.save()
+      area.save((err) => {
+        if (err != null) {
+          throw new Error('pathTokens update error.  Reason: save operation failed.')
+        }
+      })
 
       for (const childId of area.children) {
         await this.updatePathTokens(session, childId, newAreaName, index + 1)

--- a/src/model/MutableAreaDataSource.ts
+++ b/src/model/MutableAreaDataSource.ts
@@ -376,10 +376,12 @@ export default class MutableAreaDataSource extends AreaDataSource {
    * @param newAreaName new area name
    * @param depth tree depth
    */
-  async updatePathTokens (session: ClientSession, changeRecord: ChangeRecordMetadataType, area: AreaDocumnent, newAreaName: string, depth: number = 1): Promise<void> {
+  async updatePathTokens (session: ClientSession, changeRecord: ChangeRecordMetadataType, area: AreaDocumnent, newAreaName: string, changeIndex: number = -1): Promise<void> {
     if (area.pathTokens.length > 1) {
+      if (changeIndex === -1) { changeIndex = area.pathTokens.length - 1 }
+
       const newPath = [...area.pathTokens]
-      newPath[newPath.length - depth] = newAreaName
+      newPath[changeIndex] = newAreaName
       area.set({ pathTokens: newPath })
       area.set({ _change: changeRecord })
       await area.save({ session })
@@ -391,7 +393,7 @@ export default class MutableAreaDataSource extends AreaDataSource {
         // TS complains about ObjectId type
         // Fix this when we upgrade Mongoose library
         // @ts-expect-error
-        await this.updatePathTokens(session, changeRecord, childArea, newAreaName, depth + 1)
+        await this.updatePathTokens(session, changeRecord, childArea, newAreaName, changeIndex)
       }))
     }
   }

--- a/src/model/MutableAreaDataSource.ts
+++ b/src/model/MutableAreaDataSource.ts
@@ -305,16 +305,18 @@ export default class MutableAreaDataSource extends AreaDataSource {
         const sanitizedName = sanitizeStrict(areaName)
         area.set({ area_name: sanitizedName })
 
+        // change our pathTokens
         const newPath = [...area.pathTokens]
         newPath.pop()
         newPath.push(sanitizedName)
         area.set({ pathTokens: newPath })
 
+        // iterate over the DB id's in the child list and update pathTokens
         for (const childId of area.children) {
           await this.updatePathTokens(childId, sanitizedName)
         }
       }
-      
+
       if (shortCode != null) area.set({ shortCode: shortCode.toUpperCase() })
       if (isDestination != null) area.set({ 'metadata.isDestination': isDestination })
       if (isLeaf != null) area.set({ 'metadata.leaf': isLeaf })
@@ -382,17 +384,19 @@ export default class MutableAreaDataSource extends AreaDataSource {
     }
 
     if (area.pathTokens.length > 0) {
+      // copy old tokens
       const newPath = [...area.pathTokens]
+      // update the correct index in path tokens -> (length - depth)
       newPath[newPath.length - index] = newAreaName
+      // set tokens in the object and save the object to the DB
       area.set({ pathTokens: newPath })
       area.save(function (err, result) {
         if (err != null) {
           throw new Error('pathTokens update error.  Reason: save operation failed.')
-        } else {
-          console.log(result)
         }
       })
 
+      // iterate over the DB id's in the child list
       for (const childId of area.children) {
         await this.updatePathTokens(childId, newAreaName, index + 1)
       }

--- a/src/model/__tests__/updateAreas.ts
+++ b/src/model/__tests__/updateAreas.ts
@@ -299,4 +299,108 @@ describe('Areas', () => {
     await areas.updateSortingOrder(testUser,
       [{ ...change3, leftRightIndex: -1 }, { ...change4, leftRightIndex: -1 }])
   })
+
+  it('should update self and childrens pathTokens', async () => {
+    await areas.addCountry('JP')
+    const a1 = await areas.addArea(testUser, 'Parent', null, 'JP')
+    const b1 = await areas.addArea(testUser, 'B1', a1.metadata.area_id)
+    const b2 = await areas.addArea(testUser, 'B2', a1.metadata.area_id)
+    const c1 = await areas.addArea(testUser, 'C1', b1.metadata.area_id)
+    const c2 = await areas.addArea(testUser, 'C2', b1.metadata.area_id)
+    const c3 = await areas.addArea(testUser, 'C3', b2.metadata.area_id)
+    const e1 = await areas.addArea(testUser, 'E1', c3.metadata.area_id)
+
+    let a1Actual = await areas.findOneAreaByUUID(a1.metadata.area_id)
+    expect(a1Actual).toEqual(
+      expect.objectContaining({
+        area_name: 'Parent',
+        pathTokens: ['Japan', 'Parent']
+      }))
+
+    let b1Actual = await areas.findOneAreaByUUID(b1.metadata.area_id)
+    expect(b1Actual).toEqual(
+      expect.objectContaining({
+        pathTokens: ['Japan', 'Parent', 'B1']
+      }))
+
+    let b2Actual = await areas.findOneAreaByUUID(b2.metadata.area_id)
+    expect(b2Actual).toEqual(
+      expect.objectContaining({
+        pathTokens: ['Japan', 'Parent', 'B2']
+      }))
+
+    let c1Actual = await areas.findOneAreaByUUID(c1.metadata.area_id)
+    expect(c1Actual).toEqual(
+      expect.objectContaining({
+        pathTokens: ['Japan', 'Parent', 'B1', 'C1']
+      }))
+
+    let c2Actual = await areas.findOneAreaByUUID(c2.metadata.area_id)
+    expect(c2Actual).toEqual(
+      expect.objectContaining({
+        pathTokens: ['Japan', 'Parent', 'B1', 'C2']
+      }))
+
+    let c3Actual = await areas.findOneAreaByUUID(c3.metadata.area_id)
+    expect(c3Actual).toEqual(
+      expect.objectContaining({
+        pathTokens: ['Japan', 'Parent', 'B2', 'C3']
+      }))
+
+    let e1Actual = await areas.findOneAreaByUUID(e1.metadata.area_id)
+    expect(e1Actual).toEqual(
+      expect.objectContaining({
+        pathTokens: ['Japan', 'Parent', 'B2', 'C3', 'E1']
+      }))
+
+    // Update
+    const doc1: AreaEditableFieldsType = {
+      areaName: 'Test Name'
+    }
+    await areas.updateArea(testUser, a1?.metadata.area_id, doc1)
+
+    // Verify
+    a1Actual = await areas.findOneAreaByUUID(a1.metadata.area_id)
+    expect(a1Actual).toEqual(
+      expect.objectContaining({
+        area_name: 'Test Name',
+        pathTokens: ['Japan', 'Test Name']
+      }))
+
+    b1Actual = await areas.findOneAreaByUUID(b1.metadata.area_id)
+    expect(b1Actual).toEqual(
+      expect.objectContaining({
+        pathTokens: ['Japan', 'Test Name', 'B1']
+      }))
+
+    b2Actual = await areas.findOneAreaByUUID(b2.metadata.area_id)
+    expect(b2Actual).toEqual(
+      expect.objectContaining({
+        pathTokens: ['Japan', 'Test Name', 'B2']
+      }))
+
+    c1Actual = await areas.findOneAreaByUUID(c1.metadata.area_id)
+    expect(c1Actual).toEqual(
+      expect.objectContaining({
+        pathTokens: ['Japan', 'Test Name', 'B1', 'C1']
+      }))
+
+    c2Actual = await areas.findOneAreaByUUID(c2.metadata.area_id)
+    expect(c2Actual).toEqual(
+      expect.objectContaining({
+        pathTokens: ['Japan', 'Test Name', 'B1', 'C2']
+      }))
+
+    c3Actual = await areas.findOneAreaByUUID(c3.metadata.area_id)
+    expect(c3Actual).toEqual(
+      expect.objectContaining({
+        pathTokens: ['Japan', 'Test Name', 'B2', 'C3']
+      }))
+
+    e1Actual = await areas.findOneAreaByUUID(e1.metadata.area_id)
+    expect(e1Actual).toEqual(
+      expect.objectContaining({
+        pathTokens: ['Japan', 'Test Name', 'B2', 'C3', 'E1']
+      }))
+  })
 })


### PR DESCRIPTION
Issue #213 

This is a working fix for the breadcrumbs issue. It copies/updates/sets the updated areas tokens, and then calls a recursive function on each of the areas children (in this case just Mongoose object id's). The recursive function looks up the object id (queries the db), and if it has path tokens it updates the index (a depth counter is passed into each recursive call to track this index) where the name change occurred. It then sets the pathTokens in the object and saves. It will throw if the save fails or if the query for the child object returns null.

Performance varied a little in my testing. To update a large area (Central Wasatch in Utah for example) it needs to update a large tree structure, with all the associated query and save ops. This initially took about 7.5s, but in my recent testing only about 5s. I don't how much this is machine dependent, but I imagine this solution isn't performant regardless. I'll try to improve the performance where I can.

Any input on error handling and performance is welcome.