### PR TITLE
feat: add pagination support to user media query

### DIFF
--- a/src/db/MediaObjectTypes.ts
+++ b/src/db/MediaObjectTypes.ts
@@ -55,6 +55,8 @@ export interface TagsLeaderboardType {
 export interface UserMediaQueryInput {
   userUuid: string
   maxFiles?: number
+  first?: number
+  after?: string
 }
 
 /**

--- a/src/db/MediaObjectTypes.ts
+++ b/src/db/MediaObjectTypes.ts
@@ -52,11 +52,15 @@ export interface TagsLeaderboardType {
   allTime: AllTimeTagStats
 }
 
-export interface UserMediaQueryInput {
+export interface UserMediaGQLQueryInput {
   userUuid: string
   maxFiles?: number
   first?: number
   after?: string
+}
+
+export type UserMediaQueryInput = Omit<UserMediaGQLQueryInput, 'userUuid'> & {
+  userUuid: MUUID
 }
 
 /**
@@ -97,4 +101,20 @@ export interface AddEntityTagGQLInput {
 export type AddTagEntityInput = Pick<AddEntityTagGQLInput, 'entityType'> & {
   mediaId: mongoose.Types.ObjectId
   entityUuid: MUUID
+}
+
+export interface UserMedia {
+  userUuid: string
+  mediaConnection: {
+    edges: MediaEdge[]
+    pageInfo: {
+      hasNextPage: boolean
+      endCursor: string | null
+    }
+  }
+}
+
+interface MediaEdge {
+  node: MediaObject
+  cursor: string
 }

--- a/src/db/UserTypes.ts
+++ b/src/db/UserTypes.ts
@@ -1,5 +1,5 @@
 import { MUUID } from 'uuid-mongodb'
-import { MediaObject } from './MediaObjectTypes.js'
+import { UserMedia } from './MediaObjectTypes.js'
 export interface ExperimentalUserType {
   _id: MUUID
   displayName: string
@@ -64,5 +64,5 @@ export type UserPublicProfile = Pick<User, '_id' | 'displayName' | 'bio' | 'webs
 
 export interface UserPublicPage {
   profile: UserPublicProfile
-  mediaList: MediaObject[]
+  media: UserMedia
 }

--- a/src/graphql/media/queries.ts
+++ b/src/graphql/media/queries.ts
@@ -1,7 +1,15 @@
-import { TagsLeaderboardType, MediaObject, MediaByUsers, UserMediaQueryInput, MediaForFeedInput } from '../../db/MediaObjectTypes.js'
+import mongoose from 'mongoose'
+import muuid from 'uuid-mongodb'
+import { TagsLeaderboardType, MediaObject, MediaByUsers, UserMediaGQLQueryInput, MediaForFeedInput } from '../../db/MediaObjectTypes.js'
 import { Context } from '../../types.js'
 
 const MediaQueries = {
+
+  media: async (_: any, { input }, { dataSources }: Context): Promise<MediaObject> => {
+    const { media } = dataSources
+    const id = new mongoose.Types.ObjectId(input.id)
+    return await media.getOneMediaObjectById(id)
+  },
 
   getMediaForFeed: async (_, { input }, { dataSources }: Context): Promise<MediaByUsers[]> => {
     const { media } = dataSources
@@ -11,13 +19,14 @@ const MediaQueries = {
 
   getUserMedia: async (_: any, { input }, { dataSources }: Context): Promise<MediaObject[]> => {
     const { media } = dataSources
-    const { userUuid, maxFiles = 1000 } = input as UserMediaQueryInput
+    const { userUuid, maxFiles = 1000 } = input as UserMediaGQLQueryInput
     return await media.getOneUserMedia(userUuid, maxFiles)
   },
 
   getUserMediaPagination: async (_: any, { input }, { dataSources }: Context): Promise<any> => {
     const { media } = dataSources
-    return await media.getOneUserMediaPagination(input as UserMediaQueryInput)
+    const { userUuid } = input as UserMediaGQLQueryInput
+    return await media.getOneUserMediaPagination({ ...input, userUuid: muuid.from(userUuid) })
   },
 
   getTagsLeaderboard: async (_, { limit = 30 }: { limit: number }, { dataSources }: Context): Promise<TagsLeaderboardType> => {

--- a/src/graphql/media/queries.ts
+++ b/src/graphql/media/queries.ts
@@ -15,6 +15,11 @@ const MediaQueries = {
     return await media.getOneUserMedia(userUuid, maxFiles)
   },
 
+  getUserMediaPagination: async (_: any, { input }, { dataSources }: Context): Promise<any> => {
+    const { media } = dataSources
+    return await media.getOneUserMediaPagination(input as UserMediaQueryInput)
+  },
+
   getTagsLeaderboard: async (_, { limit = 30 }: { limit: number }, { dataSources }: Context): Promise<TagsLeaderboardType> => {
     const { media } = dataSources
     return await media.getTagsLeaderboard(limit)

--- a/src/graphql/schema/Media.gql
+++ b/src/graphql/schema/Media.gql
@@ -63,8 +63,9 @@ Media edge.
 See https://graphql.org/learn/pagination/
 """
 type MediaEdge {
-  ""
+  "Media object"
   node: MediaWithTags
+  "Current node cursor.  The frontend can pass this value to the `after` input parameter to fetch the next page."
   cursor: ID!
 }
 
@@ -153,12 +154,12 @@ type MediaWithTags implements IMediaMetadata {
   entityTags: [EntityTag]
 }
 
-"Input param for querying a single media object"
+"Input parameters for querying a single media object"
 input MediaInput {
   id: ID!
 }
 
-"Input param for creating a new tag"
+"Input parameters for creating a new tag"
 input MediaEntityTagInput {
   "Target media id"
   mediaId: ID!
@@ -168,21 +169,21 @@ input MediaEntityTagInput {
   entityType: Int!
 }
 
-"Input param for deleteing a tag"
+"Input parameters for deleting a tag"
 input EntityTagDeleteInput {
   mediaId: ID!
   tagId: ID!
 }
 
-"Input param for user media query"
+"Input parameters for user media queries."
 input UserMediaInput {
   "User UUID.  Ex: a0ca9ebb-aa3b-4bb0-8ddd-7c8b2ed228a5"
   userUuid: ID!
-  "Max number of objects return.  Ignore when using with pagination"
+  "Max number of objects return.  Ignore when using with pagination query."
   maxFiles: Int
-  "Number of objects per page (default to  6)."
+  "Number of objects per page (Default = 6)."
   first: Int
-  "Starting cursor ID (excluive).  Return the first page if omitted."
+  "Returning page data after this cursor (exclusive).  Return the first page if omitted."
   after: ID
 }
 

--- a/src/graphql/schema/Media.gql
+++ b/src/graphql/schema/Media.gql
@@ -21,10 +21,34 @@ type Query {
   """
   getUserMedia(input: UserMediaInput): [MediaWithTags]
 
+  getUserMediaPagination(input: UserMediaInput): [UserMedia]
+
   """
   Get a list of users and their tagged photo count
   """
   getTagsLeaderboard(limit: Int): TagsLeaderboard
+}
+
+type UserMedia {
+  username: String
+  userUuid: ID!
+  media: MediaConnection!
+}
+
+type MediaConnection {
+  # total: Int!
+  edges: [MediaEdge!]!
+  pageInfo: PageInfo!
+}
+
+type MediaEdge {
+  node: MediaWithTags
+  cursor: ID!
+}
+
+type PageInfo {
+  hasNextPage: Boolean!
+  endCursor: String
 }
 
 type TagsByUser {
@@ -124,6 +148,8 @@ input EntityTagDeleteInput {
 input UserMediaInput {
   userUuid: ID!
   maxFiles: Int
+  first: Int
+  after: ID
 }
 
 input MediaForFeedInput {

--- a/src/graphql/schema/Media.gql
+++ b/src/graphql/schema/Media.gql
@@ -12,6 +12,11 @@ type Mutation {
 
 type Query {
   """
+  Get single media object
+  """
+  media(input: MediaInput): MediaWithTags
+
+  """
   Get recent media with tags group by users.
   """
   getMediaForFeed(input: MediaForFeedInput): [MediaByUsers]
@@ -21,7 +26,13 @@ type Query {
   """
   getUserMedia(input: UserMediaInput): [MediaWithTags]
 
-  getUserMediaPagination(input: UserMediaInput): [UserMedia]
+  """
+  Get media cursor with pagination support.  We only support forward cursor.
+  See 
+  - https://graphql.org/learn/pagination/
+  - https://relay.dev/graphql/connections.htm
+  """
+  getUserMediaPagination(input: UserMediaInput): UserMedia
 
   """
   Get a list of users and their tagged photo count
@@ -29,25 +40,38 @@ type Query {
   getTagsLeaderboard(limit: Int): TagsLeaderboard
 }
 
+"""
+User media cursor with pagination support.
+See https://graphql.org/learn/pagination/
+"""
 type UserMedia {
-  username: String
   userUuid: ID!
-  media: MediaConnection!
+  mediaConnection: MediaConnection!
 }
 
+"""
+Media connection.
+See https://graphql.org/learn/pagination/
+"""
 type MediaConnection {
-  # total: Int!
   edges: [MediaEdge!]!
   pageInfo: PageInfo!
 }
 
+"""
+Media edge.
+See https://graphql.org/learn/pagination/
+"""
 type MediaEdge {
+  ""
   node: MediaWithTags
   cursor: ID!
 }
 
 type PageInfo {
+  "True if there are more data after the last cursor."
   hasNextPage: Boolean!
+  "Not yet supported."
   endCursor: String
 }
 
@@ -116,6 +140,7 @@ type EntityTag {
   lat: Float!
 }
 
+"Represent a media object"
 type MediaWithTags implements IMediaMetadata {
   id: ID!
   username: String
@@ -126,6 +151,11 @@ type MediaWithTags implements IMediaMetadata {
   uploadTime: Date!
   size: Int!
   entityTags: [EntityTag]
+}
+
+"Input param for querying a single media object"
+input MediaInput {
+  id: ID!
 }
 
 "Input param for creating a new tag"
@@ -146,9 +176,13 @@ input EntityTagDeleteInput {
 
 "Input param for user media query"
 input UserMediaInput {
+  "User UUID.  Ex: a0ca9ebb-aa3b-4bb0-8ddd-7c8b2ed228a5"
   userUuid: ID!
+  "Max number of objects return.  Ignore when using with pagination"
   maxFiles: Int
+  "Number of objects per page (default to  6)."
   first: Int
+  "Starting cursor ID (excluive).  Return the first page if omitted."
   after: ID
 }
 

--- a/src/graphql/schema/User.gql
+++ b/src/graphql/schema/User.gql
@@ -52,7 +52,7 @@ type UsernameDetail {
 
 type UserPublicPage {
   profile: UserPublicProfile
-  mediaList: [MediaWithTags]
+  media: UserMedia
 }
 
 type UserPublicProfile {

--- a/src/graphql/user/UserQueries.ts
+++ b/src/graphql/user/UserQueries.ts
@@ -1,8 +1,8 @@
 import muuid from 'uuid-mongodb'
 import { GraphQLError } from 'graphql'
 
-import { DataSourcesType, ContextWithAuth, Context } from '../../types'
-import { GetUsernameReturn, UserPublicProfile, UserPublicPage } from '../../db/UserTypes'
+import { DataSourcesType, ContextWithAuth, Context } from '../../types.js'
+import { GetUsernameReturn, UserPublicProfile, UserPublicPage } from '../../db/UserTypes.js'
 
 const UserQueries = {
 
@@ -24,7 +24,7 @@ const UserQueries = {
   },
 
   getUserPublicPage: async (_: any, { input }, { dataSources }: Context): Promise<UserPublicPage | null> => {
-    const { users, media }: DataSourcesType = dataSources
+    const { users, media: mediaDS }: DataSourcesType = dataSources
     const profile = await users.getUserPublicProfile(input.username)
     if (profile == null) {
       throw new GraphQLError('User profile not found.', {
@@ -33,10 +33,10 @@ const UserQueries = {
         }
       })
     }
-    const mediaList = await media.getOneUserMedia(profile._id.toUUID().toString(), 500)
+    const media = await mediaDS.getOneUserMediaPagination({ userUuid: profile._id })
     return {
       profile,
-      mediaList
+      media
     }
   }
 }

--- a/src/model/MediaDataSource.ts
+++ b/src/model/MediaDataSource.ts
@@ -65,8 +65,7 @@ export default class MediaDataSource extends MongoDataSource<MediaObject> {
         /**
          * Sort by most recently uploaded media first
          */
-        $sort: { createdAt: -1 }
-        // $sort: { _id: 1 }
+        $sort: { createdAt: -1, _id: -1 }
       },
       {
         $group: {
@@ -105,6 +104,16 @@ export default class MediaDataSource extends MongoDataSource<MediaObject> {
     return rs[0].mediaWithTags
   }
 
+  /**
+   * Get user media by page.
+   *
+   * See
+   * - https://engage.so/blog/a-deep-dive-into-offset-and-cursor-based-pagination-in-mongodb/#what-is-cursor-based-pagination
+   * - https://www.mixmax.com/engineering/api-paging-built-the-right-way
+   * - https://graphql.org/learn/pagination/
+   * @param input
+   * @returns
+   */
   async getOneUserMediaPagination (input: UserMediaQueryInput): Promise<UserMedia> {
     const { userUuid, first = 6, after } = input
     let nextCreatedDate: number
@@ -149,6 +158,7 @@ export default class MediaDataSource extends MongoDataSource<MediaObject> {
 
     let hasNextPage = false
     if (rs.length > first) {
+      // ok there's a next page. remove the extra item.
       rs.pop()
       hasNextPage = true
     }

--- a/src/model/MediaDataSource.ts
+++ b/src/model/MediaDataSource.ts
@@ -1,9 +1,9 @@
 import { MongoDataSource } from 'apollo-datasource-mongodb'
 import muid, { MUUID } from 'uuid-mongodb'
-import mongoose, { ObjectId } from 'mongoose'
+import mongoose from 'mongoose'
 import { logger } from '../logger.js'
 import { getMediaObjectModel } from '../db/index.js'
-import { TagsLeaderboardType, UserMediaQueryInput, AllTimeTagStats, MediaByUsers, MediaForFeedInput, MediaObject } from '../db/MediaObjectTypes.js'
+import { TagsLeaderboardType, UserMediaQueryInput, AllTimeTagStats, MediaByUsers, MediaForFeedInput, MediaObject, UserMedia } from '../db/MediaObjectTypes.js'
 
 const HARD_MAX_FILES = 1000
 const HARD_MAX_USERS = 100
@@ -19,6 +19,19 @@ export default class MediaDataSource extends MongoDataSource<MediaObject> {
       entityTags: { $exists: true, $type: 4, $ne: [] }
     }
   }]
+
+  /**
+   * Find one media object by id.  Throw an exception if not found.
+   * @param _id
+   */
+  async getOneMediaObjectById (_id: mongoose.Types.ObjectId): Promise<MediaObject> {
+    const rs = await this.mediaObjectModel.find({ _id }).orFail(new Error('Media not found')).lean()
+    if (rs != null && rs.length === 1) {
+      return rs[0]
+    }
+    logger.error(`This shouldn't happend. Found multiple media objects for id: ${_id.toString()}`)
+    throw new Error('Media not found for id')
+  }
 
   /**
    * Get all media & tags grouped by users
@@ -92,52 +105,70 @@ export default class MediaDataSource extends MongoDataSource<MediaObject> {
     return rs[0].mediaWithTags
   }
 
-  async getOneUserMediaPagination (input: UserMediaQueryInput): Promise<any> {
-    // const rs = await this.getMediaByUsers({ uuidStr, maxUsers: 1, maxFiles: limit, includesNoEntityTags: true })
-    // if (rs.length !== 1) {
-    //   logger.error(`Expecting 1 user in result set but got ${rs.length}`)
-    //   return []
-    // }
-    // return rs[0].mediaWithTags
-
-    const { userUuid: userUuidStr, first = 4, after } = input
-    let nextLaunchDate: number
+  async getOneUserMediaPagination (input: UserMediaQueryInput): Promise<UserMedia> {
+    const { userUuid, first = 6, after } = input
+    let nextCreatedDate: number
     let nextId: mongoose.Types.ObjectId
-    let filter: any[] = []
+    let filters: any
     if (after != null) {
       const d = after.split('_')
-      nextLaunchDate = Number.parseInt(d[0])
+      nextCreatedDate = Number.parseInt(d[0])
       nextId = new mongoose.Types.ObjectId(d[1])
-      filter = [{
-        $or: [
-          {
-            createdDate: { $lt: nextLaunchDate }
-          }, {
-            // If the launchDate is an exact match, we need a tiebreaker, so we use the _id field from the cursor.
-            createdDate: nextLaunchDate,
-            _id: { $lt: nextId }
-          }
-        ]
-      }]
+      filters = {
+        $match: {
+          $and: [
+            { userUuid },
+            {
+              $or: [{
+                createdAt: { $lt: new Date(nextCreatedDate) }
+              },
+              {
+                // If the created date is an exact match, we need a tiebreaker,
+                // so we use the _id field from the cursor.
+                createdAt: new Date(nextCreatedDate),
+                _id: { $lt: nextId }
+              }
+              ]
+            }
+          ]
+        }
+      }
+    } else {
+      filters = { $match: { userUuid } }
     }
 
     const rs = await this.mediaObjectModel.aggregate<MediaObject>([
-      {
-        $match: { userUuid: muid.from(userUuidStr) }
-      },
-      ...filter,
+      filters,
       {
         $sort: { createdAt: -1, _id: -1 }
       },
       {
-        $limit: first
+        $limit: first + 1 // fetch 1 extra to see if there's a next page
       }
     ])
-    console.log('#', rs)
-    const lastItem = rs[rs.length - 1]
-    const cursor = `${lastItem.createdAt.getTime()}_${lastItem._id.toString()}`
-    console.log(cursor)
-    return null
+
+    let hasNextPage = false
+    if (rs.length > first) {
+      rs.pop()
+      hasNextPage = true
+    }
+
+    return {
+      userUuid: userUuid.toUUID().toString(),
+      mediaConnection: {
+        edges: rs.map(node => (
+          {
+            node,
+            cursor: `${node.createdAt.getTime()}_${node._id.toString()}`
+          }
+        )),
+        pageInfo: {
+          hasNextPage,
+          endCursor: null
+        }
+
+      }
+    }
   }
 
   /**

--- a/src/model/__tests__/MediaDataSource.ts
+++ b/src/model/__tests__/MediaDataSource.ts
@@ -238,10 +238,9 @@ const verifyPageData = (
   expect(pageEdges).toHaveLength(itemsPerPage)
 
   /**
-   * Is there a better way to partially compare an array of objects?
    * We only need to spot check key fields.
    */
-  expect(pageEdges[0].node._id).toEqual(expectedMedia[0]._id)
-  expect(pageEdges[1].node._id).toEqual(expectedMedia[1]._id)
-  expect(pageEdges[2].node._id).toEqual(expectedMedia[2]._id)
+  pageEdges.forEach((edge, index) => {
+    expect(edge.node._id).toEqual(expectedMedia[index]._id)
+  })
 }

--- a/src/model/__tests__/MediaDataSource.ts
+++ b/src/model/__tests__/MediaDataSource.ts
@@ -6,7 +6,7 @@ import ClimbDataSource from '../MutableClimbDataSource'
 
 import { connectDB, createIndexes } from '../../db/index.js'
 import { AreaType } from '../../db/AreaTypes.js'
-import { EntityTag, MediaObject, MediaObjectGQLInput, AddTagEntityInput } from '../../db/MediaObjectTypes.js'
+import { EntityTag, MediaObject, MediaObjectGQLInput, AddTagEntityInput, UserMediaQueryInput, UserMedia } from '../../db/MediaObjectTypes.js'
 import { newSportClimb1 } from './MutableClimbDataSource.js'
 
 const TEST_MEDIA: MediaObjectGQLInput = {
@@ -163,4 +163,85 @@ describe('MediaDataSource', () => {
     // Insert the same tag again
     await expect(media.addEntityTag(areaTag2)).rejects.toThrowError(/tag already exists/i)
   })
+
+  it.only('should return paginated media cursor', async () => {
+    const ITEMS_PER_PAGE = 3
+    const MEDIA_TEMPLATE: MediaObjectGQLInput = {
+      ...TEST_MEDIA,
+      userUuid: 'a0ca9ebb-aa3b-4bb0-8ddd-7c8b2ed228a5'
+    }
+
+    /**
+     * Let's insert 7 media objects.
+     * With 3 items per page we should expect 3 pages.
+     */
+    let expectedMedia: MediaObject[] = []
+    for (let i = 0; i < 7; i = i + 1) {
+      MEDIA_TEMPLATE.mediaUrl = `/photo${i}.jpg`
+      const rs = await media.addMedia(MEDIA_TEMPLATE)
+      if (rs == null) {
+        fail('Seeding test media fail')
+      }
+      // Since the paginaton query returns most recent first
+      // we want to append new items to the front of the array
+      expectedMedia = [rs].concat(expectedMedia)
+    }
+    const input: UserMediaQueryInput = {
+      userUuid: muuid.from(MEDIA_TEMPLATE.userUuid),
+      first: ITEMS_PER_PAGE
+    }
+
+    const page1 = await media.getOneUserMediaPagination(input)
+
+    verifyPageData(page1, MEDIA_TEMPLATE.userUuid, expectedMedia.slice(0, 3), ITEMS_PER_PAGE, true)
+
+    const page1Edges = page1.mediaConnection.edges
+    const input2: UserMediaQueryInput = {
+      userUuid: muuid.from(MEDIA_TEMPLATE.userUuid),
+      first: ITEMS_PER_PAGE,
+      after: page1Edges[page1Edges.length - 1].cursor
+    }
+    const page2 = await media.getOneUserMediaPagination(input2)
+
+    verifyPageData(page2, MEDIA_TEMPLATE.userUuid, expectedMedia.slice(3, 6), ITEMS_PER_PAGE, true)
+
+    const page2Edges = page2.mediaConnection.edges
+    const input3: UserMediaQueryInput = {
+      userUuid: muuid.from(MEDIA_TEMPLATE.userUuid),
+      first: ITEMS_PER_PAGE,
+      after: page2Edges[page2Edges.length - 1].cursor
+    }
+    const page3 = await media.getOneUserMediaPagination(input3)
+
+    verifyPageData(page3, MEDIA_TEMPLATE.userUuid, expectedMedia.slice(6, 7), 1, false)
+  })
 })
+
+/**
+ * Verify media page data
+ * @param actualPage
+ * @param expectedUserUuid
+ * @param expectedMedia
+ * @param itemsPerPage
+ * @param hasNextPage
+ */
+const verifyPageData = (
+  actualPage: UserMedia,
+  expectedUserUuid: string,
+  expectedMedia: MediaObject[],
+  itemsPerPage: number,
+  hasNextPage: boolean): void => {
+  expect(actualPage.userUuid).toEqual(expectedUserUuid)
+  expect(actualPage.mediaConnection.pageInfo.hasNextPage).toStrictEqual(hasNextPage)
+
+  const pageEdges = actualPage.mediaConnection.edges
+  expect(pageEdges).toHaveLength(itemsPerPage)
+
+  /**
+   * Is there a better way to partially compare an array of objects?
+   * We only need to spot check key fields.
+   */
+  expect(pageEdges[0].node._id).toEqual(expectedMedia[0]._id)
+  expect(pageEdges[1].node._id).toEqual(expectedMedia[1]._id)
+  expect(pageEdges[2].node._id).toEqual(expectedMedia[2]._id)
+}

--- a/src/model/__tests__/MediaDataSource.ts
+++ b/src/model/__tests__/MediaDataSource.ts
@@ -164,7 +164,7 @@ describe('MediaDataSource', () => {
     await expect(media.addEntityTag(areaTag2)).rejects.toThrowError(/tag already exists/i)
   })
 
-  it.only('should return paginated media cursor', async () => {
+  it('should return paginated media results', async () => {
     const ITEMS_PER_PAGE = 3
     const MEDIA_TEMPLATE: MediaObjectGQLInput = {
       ...TEST_MEDIA,


### PR DESCRIPTION
Issue #320 
Needed by frontend PR: https://github.com/OpenBeta/open-tacos/pull/869

I followed [GQL recommended approach](https://graphql.org/learn/pagination/) for implementing a cursor-based pagination.


```gql
# Sample query
query GetNextPage {
  getUserMediaPagination(
    input: {userUuid: "b9f8ab3b-e6e5-4467-9adb-65d91c7ebe7c", first: 3, after: "1675245914389_645aa64261c73112fc19b505"}
  ) {
    userUuid
    mediaConnection {
      edges {
        cursor
        node {
          username
          mediaUrl
          entityTags {
            climbName
            id
          }
          id
        }
      }
    }
  }
}
```