### PR TITLE
Add boltsCount field

### DIFF
--- a/src/db/ClimbSchema.ts
+++ b/src/db/ClimbSchema.ts
@@ -84,6 +84,7 @@ export const ClimbSchema = new Schema<ClimbType>({
     enum: Object.values(SafetyType),
     required: true
   },
+  boltsCount: { type: Schema.Types.Number, required: false },
   metadata: MetadataSchema,
   content: ContentSchema,
   _deleting: { type: Date },

--- a/src/db/ClimbTypes.ts
+++ b/src/db/ClimbTypes.ts
@@ -40,6 +40,8 @@ export interface IClimbProps {
 
   /** Total length in metersif known.  We will support individual pitch lenth in the future. */
   length?: number
+  /** Total number of bolts (fixed anchors) */
+  boltsCount?: number
   /**
    * Grades appear within as an I18n-safe format.
    * We achieve this via a larger data encapsulation, and perform interpretation and comparison
@@ -111,6 +113,7 @@ export interface DisciplineType {
   snow?: boolean
   /** https://en.wikipedia.org/wiki/Ice_climbing */
   ice?: boolean
+  /** https://en.wikipedia.org/wiki/Mixed_climbing */
   mixed?: boolean
   /** https://en.wikipedia.org/wiki/Aid_climbing */
   aid?: boolean
@@ -155,6 +158,7 @@ export interface ClimbChangeInputType {
   description?: string
   location?: string
   protection?: string
+  boltsCount?: number
   fa?: string
   length?: number
   experimentalAuthor?: {
@@ -163,7 +167,7 @@ export interface ClimbChangeInputType {
   }
 }
 
-type UpdatableClimbFieldsType = Pick<ClimbType, 'fa' | 'name' | 'type' | 'gradeContext' | 'grades' | 'content' | 'length'>
+type UpdatableClimbFieldsType = Pick<ClimbType, 'fa' | 'name' | 'type' | 'gradeContext' | 'grades' | 'content' | 'length' | 'boltsCount'>
 /**
  * Minimum required fields when adding a new climb or boulder problem
  */

--- a/src/graphql/resolvers.ts
+++ b/src/graphql/resolvers.ts
@@ -151,6 +151,8 @@ const resolvers = {
 
     length: (node: ClimbGQLQueryType) => node.length ?? -1,
 
+    boltsCount: (node: ClimbGQLQueryType) => node.boltsCount ?? -1,
+
     grades: (node: ClimbGQLQueryType) => node.grades ?? null,
 
     metadata: (node: ClimbGQLQueryType) => {

--- a/src/graphql/schema/Climb.gql
+++ b/src/graphql/schema/Climb.gql
@@ -19,6 +19,9 @@ type Climb {
   "Total length in meters if known (-1 otherwise)"
   length: Int!
 
+  "Number of bolts/permanent anchors, if known (-1 otherwise)"
+  boltsCount: Int!
+
   "The grade(s) assigned to this climb. See GradeType documentation"
   grades: GradeType
 

--- a/src/model/MutableClimbDataSource.ts
+++ b/src/model/MutableClimbDataSource.ts
@@ -125,7 +125,7 @@ export default class MutableClimbDataSource extends ClimbDataSource {
         ? createGradeObject(grade, typeSafeDisciplines, cragGradeScales)
         : null
 
-      const { description, location, protection, name, fa, length } = userInput[i]
+      const { description, location, protection, name, fa, length, boltsCount } = userInput[i]
 
       // Make sure we don't update content = {}
       // See https://www.mongodb.com/community/forums/t/mongoservererror-invalid-set-caused-by-an-empty-object-is-not-a-valid-value/148344/2
@@ -151,6 +151,7 @@ export default class MutableClimbDataSource extends ClimbDataSource {
         gradeContext: parent.gradeContext,
         ...fa != null && { fa },
         ...length != null && length > 0 && { length },
+        ...boltsCount != null && boltsCount > 0 && { boltsCount },
         ...Object.keys(content).length > 0 && { content },
         metadata: {
           areaRef: parent.metadata.area_id,

--- a/src/model/__tests__/MutableClimbDataSource.ts
+++ b/src/model/__tests__/MutableClimbDataSource.ts
@@ -38,7 +38,7 @@ describe('Climb CRUD', () => {
       },
       description: 'The best climb',
       location: '5m left of the big tree',
-      protection: '5 quickdraws',
+      protection: '5 quickdraws'
     },
     {
       name: 'Deep water 1',
@@ -301,7 +301,7 @@ describe('Climb CRUD', () => {
       const climb1 = await climbs.findOneClimbByMUUID(muid.from(newIDs[0]))
       expect(climb1?.grades).toEqual({ ewbank: '17' })
       expect(climb1?.type.sport).toBe(true)
-      expect(newSportClimb1?.boltsCount).toEqual(2);
+      expect(newSportClimb1?.boltsCount).toEqual(2)
 
       const climb2 = await climbs.findOneClimbByMUUID(muid.from(newIDs[1]))
       expect(climb2?.grades).toEqual({ ewbank: '29/30' })

--- a/src/model/__tests__/MutableClimbDataSource.ts
+++ b/src/model/__tests__/MutableClimbDataSource.ts
@@ -19,7 +19,8 @@ export const newSportClimb1: ClimbChangeInputType = {
   },
   description: 'A good warm up problem',
   location: 'Start from the left arete',
-  protection: '2 bolts'
+  protection: '2 bolts',
+  boltsCount: 2
 }
 
 describe('Climb CRUD', () => {
@@ -37,7 +38,7 @@ describe('Climb CRUD', () => {
       },
       description: 'The best climb',
       location: '5m left of the big tree',
-      protection: '5 quickdraws'
+      protection: '5 quickdraws',
     },
     {
       name: 'Deep water 1',
@@ -300,6 +301,7 @@ describe('Climb CRUD', () => {
       const climb1 = await climbs.findOneClimbByMUUID(muid.from(newIDs[0]))
       expect(climb1?.grades).toEqual({ ewbank: '17' })
       expect(climb1?.type.sport).toBe(true)
+      expect(newSportClimb1?.boltsCount).toEqual(2);
 
       const climb2 = await climbs.findOneClimbByMUUID(muid.from(newIDs[1]))
       expect(climb2?.grades).toEqual({ ewbank: '29/30' })
@@ -407,7 +409,7 @@ describe('Climb CRUD', () => {
     expect(actual1?.updatedBy?.toUUID().toString()).toEqual(otherUser.toUUID().toString())
   })
 
-  it('can update climb length & fa', async () => {
+  it('can update climb length, boltsCount & fa', async () => {
     const newDestination = await areas.addArea(testUser, 'Sport area Z100', null, 'fr')
 
     if (newDestination == null) fail('Expect new area to be created')
@@ -421,7 +423,8 @@ describe('Climb CRUD', () => {
     const change: ClimbChangeInputType = {
       id: newIDs[0],
       fa: 'First name Last name, 2023',
-      length: 20
+      length: 20,
+      boltsCount: 5
     }
 
     await climbs.addOrUpdateClimbs(testUser,
@@ -432,10 +435,12 @@ describe('Climb CRUD', () => {
 
     expect(actual?.fa).not.toBeNull()
     expect(actual?.length).not.toBeNull()
+    expect(actual?.boltsCount).not.toBeNull()
 
     expect(actual).toMatchObject({
       fa: change.fa,
-      length: change.length
+      length: change.length,
+      boltsCount: change.boltsCount
     })
   })
 })


### PR DESCRIPTION
Add `boltsCount` to store number of fixed anchors in a route. Especially for multi-pitch climbing and sport climbing in Central Europe (where the vast majority of crags has fixed anchors).

Prerequisite to implementing multi-pitch functionality (#266).