### PR TITLE
fix: Example in README is broken (#303)

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ Get all sub-areas at Smith Rock
 
 ```graphql
 query Example1 {
-  areas(name: "Smith Rock") {
+  areas(filter: {area_name: {match: "Smith Rock"}}) {
     area_name
     children {
       area_name


### PR DESCRIPTION
Issue #303 

[Problem]
Example GraphQL query in README is broken

[Solution]
Update to correct example query in README

[Test]
1. Go here: https://cloud.hasura.io/public/graphiql?endpoint=https%3A%2F%2Fapi.openbeta.io
2. Verify the following example query works:
```
query Example1 {
  areas(filter: {area_name: {match: "Smith Rock"}}) {
    area_name
    children {
      area_name
      metadata {
        lat
        lng
      }
    }
  }
}
```

```
//Output
{
  "data": {
    "areas": [
      {
        "area_name": "(m) Smith Rock Group",
        "children": [
          {
            "area_name": "Smith Summit",
            "metadata": {
              "lat": 44.36351,
              "lng": -121.1471
            }
          }...
```
