### PR TITLE
fix: User schema should have an index on username (#315)

### DIFF
--- a/src/db/UserSchema.ts
+++ b/src/db/UserSchema.ts
@@ -67,6 +67,7 @@ export const UserSchema = new Schema<User>({
  */
 UserSchema.index({ createdAt: -1 })
 UserSchema.index({ 'usernameInfo.canonicalName': 1 }, { sparse: true, unique: true })
+UserSchema.index({ 'usernameInfo.username': 1 }, { sparse: true, unique: true })
 
 export const getUserModel = (): mongoose.Model<User> => {
   return mongoose.model('users', UserSchema)


### PR DESCRIPTION
Issue #315 

[Problem]
UserSchema performance can be improved with secondary index on username

[Solution]
Add secondary index for usernameInfo.username
