### PR TITLE
fix: Allow identical ticks on one day

### DIFF
--- a/db-migrations/0004-unique-user-climb-date-style.js
+++ b/db-migrations/0004-unique-user-climb-date-style.js
@@ -1,0 +1,11 @@
+/**
+ * https://github.com/OpenBeta/open-tacos/issues/631
+ **/
+
+rs1 = db.ticks.createIndex({ userId: -1 })
+rs2 = db.ticks.createIndex({ userId: -1, climbId: -1 })
+rs3 = db.ticks.dropIndex({ climbId: 1, dateClimbed: 1, style: 1, userId: 1, source: 1 })
+
+printjson(rs1)
+printjson(rs2)
+printjson(rs3)

--- a/src/db/TickSchema.ts
+++ b/src/db/TickSchema.ts
@@ -24,7 +24,8 @@ export const TickSchema = new Schema<TickType>({
   source: { type: Schema.Types.String, enum: ['MP', 'OB'] as TickSource[], required: true, index: true }
 })
 
-TickSchema.index({ climbId: 1, dateClimbed: 1, style: 1, userId: 1, source: 1 }, { unique: true })
+TickSchema.index({ userId: 1 }) // for ticksByUser()
+TickSchema.index({ userId: 1, climbId: 1 }) // for ticksByUserIdAndClimb()
 
 export const getTickModel = (name: string = 'ticks'): mongoose.Model<TickType> => {
   return mongoose.model(name, TickSchema)

--- a/src/model/__tests__/ticks.ts
+++ b/src/model/__tests__/ticks.ts
@@ -185,24 +185,4 @@ describe('Ticks', () => {
     expect(newTick?._id).toEqual(OBTick._id)
     expect(newTick?.notes).toEqual('Not sandbagged')
   })
-
-  it('should reject duplicate ticks', async () => {
-    const tick1: TickInput = {
-      name: 'Small Dog',
-      notes: 'Not sandbagged',
-      climbId: 'c76d2083-6b8f-524a-8fb8-76e1dc79833f',
-      userId: 'user123',
-      style: 'Lead',
-      attemptType: 'Fell/Hung',
-      dateClimbed: new Date('2012-12-12'),
-      grade: '5.7',
-      source: 'OB'
-    }
-
-    await ticks.addTick(tick1)
-
-    await expect(
-      ticks.addTick(tick1)
-    ).rejects.toThrow()
-  })
 })


### PR DESCRIPTION
The schema enforces a unique index on {climbId, dateClimbed, style, userID, source}.  This is meant to prevent duplicating ticks imported from mountain project.  However, it also prevents logging such ticks when they are legitimate.

The import procedure also deletes imported ticks before reimporting, so this was overly cautious.

Change the schema so it does not enforce uniqueness in this way. Instead, add non-unique indexes on { userId } and { userId, climbId }.

Add a db migration script.

Remove climb uniqueness test.

Fixes https://github.com/OpenBeta/open-tacos/issues/631