### PR TITLE
feat: support area type when adding new areas

### DIFF
--- a/src/graphql/area/AreaMutations.ts
+++ b/src/graphql/area/AreaMutations.ts
@@ -29,7 +29,7 @@ const AreaMutations = {
 
   addArea: async (_, { input }, { dataSources, user }: ContextWithAuth): Promise<AreaType | null> => {
     const { areas } = dataSources
-    const { name, parentUuid, countryCode, experimentalAuthor } = input
+    const { name, parentUuid, countryCode, experimentalAuthor, isLeaf, isBoulder } = input
 
     // permission middleware shouldn't send undefined uuid
     if (user?.uuid == null) throw new Error('Missing user uuid')
@@ -38,7 +38,9 @@ const AreaMutations = {
       user.uuid, name,
       parentUuid == null ? null : muuid.from(parentUuid),
       countryCode,
-      experimentalAuthor
+      experimentalAuthor,
+      isLeaf,
+      isBoulder
     )
   },
 

--- a/src/graphql/schema/AreaEdit.gql
+++ b/src/graphql/schema/AreaEdit.gql
@@ -39,6 +39,8 @@ input AreaInput {
   parentUuid: ID
   countryCode: String
   isDestination: Boolean
+  isLeaf: Boolean
+  isBoulder: Boolean
   experimentalAuthor: ExperimentalAuthorType
 }
 

--- a/src/model/__tests__/updateAreas.ts
+++ b/src/model/__tests__/updateAreas.ts
@@ -109,6 +109,16 @@ describe('Areas', () => {
     expect(countryInDb.children[0]).toEqual(area?._id)
   })
 
+  it('should set crag/boulder attribute when adding new areas', async () => {
+    let parent = await areas.addArea(testUser, 'Boulder A', null, 'can', undefined, false, true)
+    expect(parent.metadata.isBoulder).toBe(true)
+    expect(parent.metadata.leaf).toBe(true)
+
+    parent = await areas.addArea(testUser, 'Sport A', null, 'can', undefined, true, undefined)
+    expect(parent.metadata.isBoulder).toBe(false)
+    expect(parent.metadata.leaf).toBe(true)
+  })
+
   it('should update multiple fields', async () => {
     await areas.addCountry('au')
     const a1 = await areas.addArea(testUser, 'One', null, 'au')


### PR DESCRIPTION
The current addArea mutation doesn't accept area type in the input parameters.

This PR adds optional area type in the input params to support creating new crag and boulder in 1 call.

Issue https://github.com/OpenBeta/open-tacos/issues/709