### PR TITLE
chore: Update sandbag version

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "@babel/runtime": "^7.17.2",
     "@google-cloud/storage": "^6.9.5",
     "@graphql-tools/schema": "^8.3.1",
-    "@openbeta/sandbag": "^0.0.45",
+    "@openbeta/sandbag": "^0.0.48",
     "@turf/area": "^6.5.0",
     "@turf/bbox": "^6.5.0",
     "@turf/bbox-polygon": "^6.5.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1579,10 +1579,10 @@
     "@nodelib/fs.scandir" "2.1.5"
     fastq "^1.6.0"
 
-"@openbeta/sandbag@^0.0.45":
-  version "0.0.45"
-  resolved "https://registry.yarnpkg.com/@openbeta/sandbag/-/sandbag-0.0.45.tgz#b6230ddf63f265b91d0a0359a2f87c5359dded74"
-  integrity sha512-8s2YFeUBU3lK2EzQIZSsf/apEIaxhtHJNfWWDmtjIE7/wlgqm84BSX72wur1FGrqcI9o3P1dkZmevHnu0ItGZQ==
+"@openbeta/sandbag@^0.0.48":
+  version "0.0.48"
+  resolved "https://registry.yarnpkg.com/@openbeta/sandbag/-/sandbag-0.0.48.tgz#d876ae47634c287be1f71858576a9f826f8ee270"
+  integrity sha512-QyTGG9Y+c+2TY+EbdUByAAr1u7qyqZ4H1ZM0TztetJU/a7TLjdMoR32yaRY8uSFvm3f1sP0zn0ffhlLiICDdlg==
 
 "@panva/asn1.js@^1.0.0":
   version "1.0.0"


### PR DESCRIPTION
Update to sandbag 0.0.48 to get

- fixed slash grades (https://github.com/OpenBeta/sandbag/pull/143)
- fixed VB grades (https://github.com/OpenBeta/sandbag/pull/147)
- fixed YDS grades > 5.9 with no letter (https://github.com/OpenBeta/sandbag/pull/138)