### PR TITLE
feat: add Brazilian grade context (closes #358)

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "@babel/runtime": "^7.17.2",
     "@google-cloud/storage": "^6.9.5",
     "@graphql-tools/schema": "^8.3.1",
-    "@openbeta/sandbag": "^0.0.48",
+    "@openbeta/sandbag": "^0.0.51",
     "@turf/area": "^6.5.0",
     "@turf/bbox": "^6.5.0",
     "@turf/bbox-polygon": "^6.5.0",

--- a/src/GradeUtils.ts
+++ b/src/GradeUtils.ts
@@ -15,6 +15,7 @@ export enum GradeContexts {
   ALSK = 'ALSK',
   /** Australia */
   AU = 'AU',
+  /** Brazil */
   BRZ = 'BRZ',
   FIN = 'FIN',
   FR = 'FR',
@@ -96,6 +97,22 @@ export const gradeContextToGradeScales: Partial<Record<GradeContexts, ClimbGrade
     aid: GradeScales.UIAA,
     snow: GradeScales.UIAA, // TODO: remove `snow` since it duplicates `ice`
     ice: GradeScales.WI
+  },
+  [GradeContexts.BRZ]: {
+    trad: GradeScales.BRAZILIAN_CRUX,
+    sport: GradeScales.BRAZILIAN_CRUX,
+    bouldering: GradeScales.VSCALE,
+    tr: GradeScales.BRAZILIAN_CRUX,
+    deepwatersolo: GradeScales.BRAZILIAN_CRUX,
+    alpine: GradeScales.BRAZILIAN_CRUX,
+    mixed: GradeScales.BRAZILIAN_CRUX,
+    aid: GradeScales.AID,
+    // definitely no ice in brazil, however once this guy
+    // top roped a fragile frozen waterfall with ice picks
+    // and crampons:
+    ice: GradeScales.WI,
+    // whenever it snows in brazil, you see it in the news
+    snow: GradeScales.WI
   }
 }
 

--- a/src/__tests__/gradeUtils.ts
+++ b/src/__tests__/gradeUtils.ts
@@ -175,4 +175,36 @@ describe('Test grade utilities', () => {
     actual = createGradeObject('5.9', sanitizeDisciplines({ bouldering: true }), context)
     expect(actual).toBeUndefined()
   })
+
+  it('creates grade object correctly in BRZ context', () => {
+    const context = gradeContextToGradeScales.BRZ
+    if (context == null) { fail('Bad grade context.  Should not happen.') }
+    let actual = createGradeObject('V', sanitizeDisciplines({ sport: true }), context)
+    expect(actual).toEqual({
+      brazilian_crux: 'V'
+    })
+    actual = createGradeObject('A2', sanitizeDisciplines({ aid: true }), context)
+    expect(actual).toEqual({
+      aid: 'A2'
+    })
+    actual = createGradeObject('C1', sanitizeDisciplines({ aid: true }), context)
+    expect(actual).toEqual({
+      aid: 'C1'
+    })
+    actual = createGradeObject('V5', sanitizeDisciplines({ bouldering: true }), context)
+    expect(actual).toEqual({
+      vscale: 'V5'
+    })
+    actual = createGradeObject('WI6', sanitizeDisciplines({ ice: true }), context)
+    expect(actual).toEqual({
+      wi: 'WI6'
+    })
+    actual = createGradeObject('VIIb', sanitizeDisciplines({ deepwatersolo: true }), context)
+    expect(actual).toEqual({
+      brazilian_crux: 'VIIb'
+    })
+    // Invalid input
+    actual = createGradeObject('5.9', sanitizeDisciplines({ bouldering: true }), context)
+    expect(actual).toBeUndefined()
+  })
 })

--- a/src/db/ClimbSchema.ts
+++ b/src/db/ClimbSchema.ts
@@ -63,6 +63,7 @@ const GradeTypeSchema = new Schema<GradeScalesTypes>({
   vscale: Schema.Types.String,
   yds: { type: Schema.Types.String, required: false },
   ewbank: { type: Schema.Types.String, required: false },
+  brazilian_crux: { type: Schema.Types.String, required: false },
   french: { type: Schema.Types.String, required: false },
   font: { type: Schema.Types.String, required: false },
   UIAA: { type: Schema.Types.String, required: false }

--- a/src/db/ClimbTypes.ts
+++ b/src/db/ClimbTypes.ts
@@ -103,6 +103,7 @@ export enum SafetyType {
 export interface IGradeType {
   yds?: string
   ewbank?: string
+  brazilianCrux?: string
   french?: string
   font?: string
   uiaa?: string

--- a/src/db/import/ClimbTransformer.ts
+++ b/src/db/import/ClimbTransformer.ts
@@ -28,7 +28,8 @@ const transformClimbRecord = (row: any): ClimbType => {
       ewbank: grade.Ewbank,
       font: grade.Font,
       french: grade.French,
-      uiaa: grade.UIAA
+      uiaa: grade.UIAA,
+      brazilian_crux: grade.BrazilianCrux
     },
     gradeContext,
     safety,

--- a/src/graphql/schema/Climb.gql
+++ b/src/graphql/schema/Climb.gql
@@ -154,6 +154,7 @@ type GradeType {
   """
   ewbank: String
   french: String
+  brazilianCrux: String
   """
   Fontainebleau grading system, the most widely used grading system in Europe.
   Mostly used for bouldering.

--- a/yarn.lock
+++ b/yarn.lock
@@ -1579,10 +1579,10 @@
     "@nodelib/fs.scandir" "2.1.5"
     fastq "^1.6.0"
 
-"@openbeta/sandbag@^0.0.48":
-  version "0.0.48"
-  resolved "https://registry.yarnpkg.com/@openbeta/sandbag/-/sandbag-0.0.48.tgz#d876ae47634c287be1f71858576a9f826f8ee270"
-  integrity sha512-QyTGG9Y+c+2TY+EbdUByAAr1u7qyqZ4H1ZM0TztetJU/a7TLjdMoR32yaRY8uSFvm3f1sP0zn0ffhlLiICDdlg==
+"@openbeta/sandbag@^0.0.51":
+  version "0.0.51"
+  resolved "https://registry.yarnpkg.com/@openbeta/sandbag/-/sandbag-0.0.51.tgz#21ce618d2414dc0b8d4f31ef260ac2ebad5a43c8"
+  integrity sha512-qMVohgqRdFjXH8a3aSEZa6zemwSpak/HMttR/pqvclDIXqgPKzWvjFRA3o/YDGieI/19P4dtizLo91TKx0smGQ==
 
 "@panva/asn1.js@^1.0.0":
   version "1.0.0"


### PR DESCRIPTION
This PR introduces and links Brazilian Crux grade to the backend.

@musoke This was my first interaction with graphql so I'm not sure if there's any missing pieces, the codebase seemed ready to accept a new context without much tweaking.
