### PR TITLE
build: skip dockerhub login if it's a PR

### DIFF
--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -82,6 +82,7 @@ jobs:
 
       - name: Login to DockerHub
         uses: docker/login-action@v2
+        if: github.event_name != 'pull_request'
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}


### PR DESCRIPTION
we are only pushing to docker hub if it's not a PR (i.e. main branch, tags). there's no point in performing dockerhub login if we are no pushing anything.