### PR TITLE
fix: remove uniqueness requirement for area's L-R indices

### DIFF
--- a/db-migrations/0005-area-sorting.js
+++ b/db-migrations/0005-area-sorting.js
@@ -1,0 +1,5 @@
+/**
+ * Issue: 375
+ */
+
+db.areas.dropIndexes('metadata.leftRightIndex_1')

--- a/src/db/AreaSchema.ts
+++ b/src/db/AreaSchema.ts
@@ -118,8 +118,9 @@ export const AreaSchema = new Schema<AreaType>({
 }, { timestamps: true })
 
 AreaSchema.index({ _deleting: 1 }, { expireAfterSeconds: 0 })
-AreaSchema.index({ 'metadata.leftRightIndex': 1 }, {
-  unique: true,
+AreaSchema.index({
+  'metadata.leftRightIndex': 1
+}, {
   partialFilterExpression: {
     'metadata.leftRightIndex': {
       $gt: -1

--- a/src/model/__tests__/updateAreas.ts
+++ b/src/model/__tests__/updateAreas.ts
@@ -286,28 +286,6 @@ describe('Areas', () => {
           leftRightIndex: change2.leftRightIndex
         })
       }))
-
-    // Able to overwrite existing leftRightIndices without duplicate key errors
-    const change3: UpdateSortingOrderType = {
-      areaId: a1.metadata.area_id.toUUID().toString(),
-      leftRightIndex: 9
-    }
-    const change4: UpdateSortingOrderType = {
-      areaId: a2.metadata.area_id.toUUID().toString(),
-      leftRightIndex: 10
-    }
-
-    await expect(areas.updateSortingOrder(testUser, [change3, change4])).resolves.toStrictEqual(
-      [a1.metadata.area_id.toUUID().toString(), a2.metadata.area_id.toUUID().toString()])
-
-    // Make sure we can't have duplicate leftToRight indices >= 0
-    await expect(
-      areas.updateSortingOrder(testUser, [{ ...change3, leftRightIndex: change4.leftRightIndex }]))
-      .rejects.toThrowError(/E11000/)
-
-    // But we can have duplicate indices < 0 to indicate unsorted
-    await areas.updateSortingOrder(testUser,
-      [{ ...change3, leftRightIndex: -1 }, { ...change4, leftRightIndex: -1 }])
   })
 
   it('should update self and childrens pathTokens', async () => {


### PR DESCRIPTION
- [x] Removed area left-to-right index unique flag and related code.  Since child areas are nested documents in the parent area, we have to create a compound index on the parent.area_id + child area's left-right-index, which is not possible.
- [x] Removed old index in staging and prod db

Fix #375 