### PR TITLE
feat: add ticks field to climb query

### DIFF
--- a/src/graphql/resolvers.ts
+++ b/src/graphql/resolvers.ts
@@ -15,7 +15,7 @@ import { MediaMutations, MediaQueries, MediaResolvers } from './media/index.js'
 import { AreaMutations, AreaQueries } from './area/index.js'
 import { ClimbMutations } from './climb/index.js'
 import { OrganizationMutations, OrganizationQueries } from './organization/index.js'
-import { TickMutations, TickQueries } from './tick/index.js'
+import { TickMutations, TickQueries, TickResolvers } from './tick/index.js'
 import { UserMutations, UserQueries, UserResolvers } from './user/index.js'
 import { getAuthorMetadataFromBaseNode } from '../db/utils/index.js'
 import { geojsonPointToLatitude, geojsonPointToLongitude } from '../utils/helpers.js'
@@ -118,6 +118,7 @@ const resolvers = {
   ...MediaResolvers,
   ...HistoryFieldResolvers,
   ...UserResolvers,
+  ...TickResolvers,
   JSONObject: GraphQLJSONObject,
 
   Climb: {
@@ -188,7 +189,13 @@ const resolvers = {
         }
       : node.content,
 
-    authorMetadata: getAuthorMetadataFromBaseNode
+    authorMetadata: getAuthorMetadataFromBaseNode,
+
+    ticks: async (node: ClimbGQLQueryType, _: any, { dataSources }: GQLContext) => {
+      const { ticks } = dataSources
+      return await ticks.ticksByUserIdAndClimb(node._id.toUUID().toString())
+    }
+
   },
 
   Area: {

--- a/src/graphql/schema/Climb.gql
+++ b/src/graphql/schema/Climb.gql
@@ -67,6 +67,9 @@ type Climb {
 
   "Metadata about creation & update of this climb"
   authorMetadata: AuthorMetadata!
+
+  "User ticks of this climb"
+  ticks: [TickType]
 }
 
 type ClimbMetadata {

--- a/src/graphql/schema/Tick.gql
+++ b/src/graphql/schema/Tick.gql
@@ -104,6 +104,9 @@ type TickType {
   """
   grade: String
   source: TickSource
+
+  """User public profile"""
+  user: UserPublicProfile!
 }
 
 "The tick sources that openbeta supports."

--- a/src/graphql/tick/TickQueries.ts
+++ b/src/graphql/tick/TickQueries.ts
@@ -9,7 +9,7 @@ const TickQueries = {
   userTicksByClimbId: async (_, input, { dataSources }): Promise<TickType[] | null> => {
     const { ticks }: { ticks: TickDataSource } = dataSources
     const { climbId, userId } = input
-    return await ticks.ticksByUserIdAndClimb(userId, climbId)
+    return await ticks.ticksByUserIdAndClimb(climbId, userId)
   }
 }
 

--- a/src/graphql/tick/TickResolvers.ts
+++ b/src/graphql/tick/TickResolvers.ts
@@ -1,0 +1,12 @@
+import muuid from 'uuid-mongodb'
+import { TickType } from '../../db/TickTypes.js'
+import { GQLContext } from '../../types.js'
+
+export const TickResolvers = {
+  TickType: {
+    user: async (node: TickType, args: any, { dataSources }: GQLContext) => {
+      const { users } = dataSources
+      return await users.getUserPublicProfileByUuid(muuid.from(node.userId))
+    }
+  }
+}

--- a/src/graphql/tick/index.ts
+++ b/src/graphql/tick/index.ts
@@ -1,4 +1,5 @@
 import TickMutations from './TickMutations.js'
 import TickQueries from './TickQueries.js'
+import { TickResolvers } from './TickResolvers.js'
 
-export { TickMutations, TickQueries }
+export { TickMutations, TickQueries, TickResolvers }

--- a/src/model/TickDataSource.ts
+++ b/src/model/TickDataSource.ts
@@ -106,8 +106,13 @@ export default class TickDataSource extends MongoDataSource<TickType> {
     return await this.tickModel.find({ userId: userIdObject._id.toUUID().toString() })
   }
 
-  async ticksByUserIdAndClimb (userId: string, climbId: string): Promise<TickType[]> {
-    return await this.tickModel.find({ userId, climbId })
+  /**
+   * Get all ticks by climb uuid and optional user uuid
+   * @param userId Optional user uuid
+   * @param climbId climb uuid
+   */
+  async ticksByUserIdAndClimb (climbId: string, userId?: string): Promise<TickType[]> {
+    return await this.tickModel.find({ ...(userId != null && { userId }), climbId }).sort({ dateClimbed: -1 }).lean()
   }
 
   static instance: TickDataSource

--- a/src/model/__tests__/ticks.ts
+++ b/src/model/__tests__/ticks.ts
@@ -156,7 +156,7 @@ describe('Ticks', () => {
     if (tick == null || tick2 == null) {
       fail('Should add a new tick')
     }
-    const userClimbTicks = await ticks.ticksByUserIdAndClimb(userId.toUUID().toString(), climbId)
+    const userClimbTicks = await ticks.ticksByUserIdAndClimb(climbId, userId.toUUID().toString())
     expect(userClimbTicks.length).toEqual(1)
   })
 


### PR DESCRIPTION
Partially addressed #423 #426 
- [x] feat: add user public profile to tick query
- [x] feat: add ticks field to climb query
- [x] fix: getTicksByUserId and climb id returns results by climbed date (most recent first)

<img width="1031" alt="Screenshot 2024-11-28 at 5 03 57 PM" src="https://github.com/user-attachments/assets/660bfc3b-486d-4278-922c-f4415d931d3c">
