### PR TITLE
feat: introduce climb field in tick

### DIFF
--- a/src/graphql/schema/Tick.gql
+++ b/src/graphql/schema/Tick.gql
@@ -107,6 +107,9 @@ type TickType {
 
   """User public profile"""
   user: UserPublicProfile!
+
+  """The climb associated with this tick. Null when the climb doesn't exist in our database."""
+  climb: Climb
 }
 
 "The tick sources that openbeta supports."

--- a/src/graphql/tick/TickResolvers.ts
+++ b/src/graphql/tick/TickResolvers.ts
@@ -7,6 +7,11 @@ export const TickResolvers = {
     user: async (node: TickType, args: any, { dataSources }: GQLContext) => {
       const { users } = dataSources
       return await users.getUserPublicProfileByUuid(muuid.from(node.userId))
+    },
+
+    climb: async (node: TickType, args: any, { dataSources }: GQLContext) => {
+      const { areas } = dataSources
+      return await areas.findOneClimbByUUID(muuid.from(node.climbId))
     }
   }
 }


### PR DESCRIPTION
Fix #423
This PR and PR #431 introduce `user` and `climb` field to each tick.  This is a simple implementation which doesn't account for n+1 problem.  For example, if a climb has 5 ticks, to get the user object for each tick, the backend makes 5 additional queries.