### PR TITLE
feat: switch to our own typesense

### DIFF
--- a/.env
+++ b/.env
@@ -12,8 +12,9 @@ DEPLOYMENT_ENV=development
 CDN_URL=https://storage.googleapis.com/openbeta-staging
 
 # Typesense
-TYPESENSE_NODE=4wknoyspjq6l7c9fp-1.a1.typesense.net
-TYPESENSE_API_KEY_RW=define_me
+TYPESENSE_NODE=typesense-01.openbeta.io
+TYPESENSE_API_KEY_RW=ask_us_on_Discord
+
 # Auth0
 AUTH0_DOMAIN=https://dev-fmjy7n5n.us.auth0.com
 AUTH0_KID=uciP2tJdJ4BKWoz73Fmln

--- a/src/db/export/queries/defaults.ts
+++ b/src/db/export/queries/defaults.ts
@@ -1,4 +1,4 @@
 /**
  * The maximum default number of documents to query from the database at once.
  */
-export const DEFAULT_CHUNK_SIZE = 5000
+export const DEFAULT_CHUNK_SIZE = 1000


### PR DESCRIPTION
Due to rising Typesense cloud cost we're switching to our self-hosted Typesense