### PR TITLE
feat: add totalItems to userMediaSource

### DIFF
--- a/src/db/MediaObjectTypes.ts
+++ b/src/db/MediaObjectTypes.ts
@@ -117,6 +117,7 @@ export interface UserMedia {
     edges: MediaEdge[]
     pageInfo: {
       hasNextPage: boolean
+      totalItems: number
       endCursor: string | null
     }
   }

--- a/src/graphql/schema/Media.gql
+++ b/src/graphql/schema/Media.gql
@@ -86,6 +86,8 @@ type MediaEdge {
 type PageInfo {
   "True if there are more data after the last cursor."
   hasNextPage: Boolean!
+  "Total number of items."
+  totalItems: Int!
   "Not yet supported."
   endCursor: String
 }

--- a/src/model/MediaDataSource.ts
+++ b/src/model/MediaDataSource.ts
@@ -167,6 +167,8 @@ export default class MediaDataSource extends MongoDataSource<MediaObject> {
       }
     ])
 
+    const itemCount = await this.mediaObjectModel.countDocuments({ userUuid })
+
     let hasNextPage = false
     if (rs.length > first) {
       // ok there's a next page. remove the extra item.
@@ -185,6 +187,7 @@ export default class MediaDataSource extends MongoDataSource<MediaObject> {
         )),
         pageInfo: {
           hasNextPage,
+          totalItems: itemCount,
           endCursor: null
         }
 

--- a/src/model/__tests__/MediaDataSource.ts
+++ b/src/model/__tests__/MediaDataSource.ts
@@ -221,7 +221,8 @@ describe('MediaDataSource', () => {
      * With 3 items per page we should expect 3 pages.
      */
     const newMediaListInput: MediaObjectGQLInput[] = []
-    for (let i = 0; i < 7; i = i + 1) {
+    const mediaCount = 7
+    for (let i = 0; i < mediaCount; i = i + 1) {
       newMediaListInput.push({ ...MEDIA_TEMPLATE, mediaUrl: `/photo${i}.jpg` })
     }
 
@@ -241,7 +242,7 @@ describe('MediaDataSource', () => {
 
     const page1 = await media.getOneUserMediaPagination(input)
 
-    verifyPageData(page1, MEDIA_TEMPLATE.userUuid, expectedMedia.slice(0, 3), ITEMS_PER_PAGE, true)
+    verifyPageData(page1, MEDIA_TEMPLATE.userUuid, expectedMedia.slice(0, 3), mediaCount, ITEMS_PER_PAGE, true)
 
     const page1Edges = page1.mediaConnection.edges
     const input2: UserMediaQueryInput = {
@@ -251,7 +252,7 @@ describe('MediaDataSource', () => {
     }
     const page2 = await media.getOneUserMediaPagination(input2)
 
-    verifyPageData(page2, MEDIA_TEMPLATE.userUuid, expectedMedia.slice(3, 6), ITEMS_PER_PAGE, true)
+    verifyPageData(page2, MEDIA_TEMPLATE.userUuid, expectedMedia.slice(3, 6), mediaCount, ITEMS_PER_PAGE, true)
 
     const page2Edges = page2.mediaConnection.edges
     const input3: UserMediaQueryInput = {
@@ -261,7 +262,7 @@ describe('MediaDataSource', () => {
     }
     const page3 = await media.getOneUserMediaPagination(input3)
 
-    verifyPageData(page3, MEDIA_TEMPLATE.userUuid, expectedMedia.slice(6, 7), 1, false)
+    verifyPageData(page3, MEDIA_TEMPLATE.userUuid, expectedMedia.slice(6, 7), mediaCount, 1, false)
   })
 })
 
@@ -270,6 +271,7 @@ describe('MediaDataSource', () => {
  * @param actualPage
  * @param expectedUserUuid
  * @param expectedMedia
+ * @param totalItems
  * @param itemsPerPage
  * @param hasNextPage
  */
@@ -277,11 +279,12 @@ const verifyPageData = (
   actualPage: UserMedia,
   expectedUserUuid: string,
   expectedMedia: MediaObject[],
+  totalItems: number,
   itemsPerPage: number,
   hasNextPage: boolean): void => {
   expect(actualPage.userUuid).toEqual(expectedUserUuid)
   expect(actualPage.mediaConnection.pageInfo.hasNextPage).toStrictEqual(hasNextPage)
-
+  expect(actualPage.mediaConnection.pageInfo.totalItems).toStrictEqual(totalItems)
   const pageEdges = actualPage.mediaConnection.edges
   expect(pageEdges).toHaveLength(itemsPerPage)
 


### PR DESCRIPTION
Add `totalItems` to the getUserMediaPagination API (mediaConnection/pageInfo)

![Screenshot 2025-02-11 at 5 13 31 PM](https://github.com/user-attachments/assets/e4685173-754e-4777-acfc-7794cfed356a)
