### PR TITLE
Feat: Location or Approach field for Areas (will have separate FE PR)

### DIFF
--- a/src/db/AreaSchema.ts
+++ b/src/db/AreaSchema.ts
@@ -62,7 +62,8 @@ const MetadataSchema = new Schema<IAreaMetadata>({
 }, { _id: false })
 
 const ContentSchema = new Schema<IAreaContent>({
-  description: { type: Schema.Types.String }
+  description: { type: Schema.Types.String },
+  areaLocation: { type: Schema.Types.String }
 }, { _id: false })
 
 export const CountByGroup = new Schema<CountByGroupType>({

--- a/src/db/AreaTypes.ts
+++ b/src/db/AreaTypes.ts
@@ -162,14 +162,15 @@ export interface IAreaMetadata {
 }
 
 export interface IAreaContent {
-  /** longform to mediumform description of this area.
-   * Remembering that areas can be the size of countries, or as precise as a single cliff/boulder,
+  /** longform to mediumform description and location of this area.
+   * Remembering that area descriptions can be the size of countries, or as precise as a single cliff/boulder,
    * there is not a single definition of valid content for this field.
    *
    * We expect users to make a call about whatever kind of context may be appropriate for this
    * entity, and may be pretty short to extremely detailed.
    */
   description?: string
+  areaLocation?: string
 }
 
 /** Fields that may be directly modified by users.
@@ -179,6 +180,7 @@ export interface IAreaContent {
 export interface AreaEditableFieldsType {
   areaName?: string
   description?: string
+  areaLocation?: string
   isDestination?: boolean
   isLeaf?: boolean
   isBoulder?: boolean

--- a/src/db/import/usa/AreaTransformer.ts
+++ b/src/db/import/usa/AreaTransformer.ts
@@ -110,7 +110,9 @@ export const makeDBArea = (node: AreaNode): AreaType => {
     density: 0,
     totalClimbs: 0,
     content: {
-      description: isLeaf ? (Array.isArray(node.jsonLine.description) ? node.jsonLine.description.join('\n\n') : '') : ''
+      description: isLeaf ? (Array.isArray(node.jsonLine.description) ? node.jsonLine.description.join('\n\n') : '') : '',
+      // TODO: mike fix this by creating a new area and testing
+      areaLocation: isLeaf ? (Array.isArray(node.jsonLine.areaLocation) ? node.jsonLine.areaLocation.join('\n\n') : '') : ''
     }
   }
 }

--- a/src/db/import/usa/AreaTransformer.ts
+++ b/src/db/import/usa/AreaTransformer.ts
@@ -111,7 +111,6 @@ export const makeDBArea = (node: AreaNode): AreaType => {
     totalClimbs: 0,
     content: {
       description: isLeaf ? (Array.isArray(node.jsonLine.description) ? node.jsonLine.description.join('\n\n') : '') : '',
-      // TODO: mike fix this by creating a new area and testing
       areaLocation: isLeaf ? (Array.isArray(node.jsonLine.areaLocation) ? node.jsonLine.areaLocation.join('\n\n') : '') : ''
     }
   }

--- a/src/graphql/schema/Area.gql
+++ b/src/graphql/schema/Area.gql
@@ -158,6 +158,7 @@ type CountByGradeBand {
 
 type AreaContent {
   description: String
+  areaLocation: String
 }
 
 input Point {

--- a/src/graphql/schema/AreaEdit.gql
+++ b/src/graphql/schema/AreaEdit.gql
@@ -173,6 +173,7 @@ input AreEditableFieldsInput {
   lat: Float
   lng: Float
   description: String
+  areaLocation: String
   experimentalAuthor: ExperimentalAuthorType
   leftRightIndex: Int
 }

--- a/src/model/MutableAreaDataSource.ts
+++ b/src/model/MutableAreaDataSource.ts
@@ -401,6 +401,7 @@ export default class MutableAreaDataSource extends AreaDataSource {
       const {
         areaName,
         description,
+        areaLocation,
         shortCode,
         isDestination,
         isLeaf,
@@ -464,6 +465,10 @@ export default class MutableAreaDataSource extends AreaDataSource {
       if (description != null) {
         const sanitized = sanitizeStrict(description)
         area.set({ 'content.description': sanitized })
+      }
+      if (areaLocation != null) {
+        const sanitized = sanitizeStrict(areaLocation)
+        area.set({ 'content.areaLocation': sanitized })
       }
 
       const latLngHasChanged = lat != null && lng != null
@@ -697,7 +702,8 @@ export const newAreaHelper = (areaName: string, parentAncestors: string, parentP
     density: 0,
     totalClimbs: 0,
     content: {
-      description: ''
+      description: '',
+      areaLocation: ''
     }
   }
 }

--- a/src/model/__tests__/updateAreas.ts
+++ b/src/model/__tests__/updateAreas.ts
@@ -126,12 +126,13 @@ describe('Areas', () => {
     if (a1 == null) {
       fail()
     }
-    // for testing area desccription is sanitized
+    // for testing area description and location is sanitized
     const iframeStr = '<iframe src="https://www.googlecom" title="Evil Iframe"></iframe>'
     const doc1: AreaEditableFieldsType = {
       areaName: '1',
       shortCode: 'ONE',
       description: `This is a cool area with some malicious code.${iframeStr}`,
+      areaLocation: `This is a cool area location with some malicious code.${iframeStr}`,
       isDestination: true
     }
     let a1Updated = await areas.updateArea(testUser, a1?.metadata.area_id, doc1)
@@ -140,6 +141,8 @@ describe('Areas', () => {
     expect(a1Updated?.shortCode).toEqual(doc1.shortCode)
     // make sure area description is sanitized
     expect(a1Updated?.content.description).toEqual(doc1.description?.replace(iframeStr, ''))
+    // make sure area location is sanitized
+    expect(a1Updated?.content.areaLocation).toEqual(doc1.areaLocation?.replace(iframeStr, ''))
     expect(a1Updated?.metadata.isDestination).toEqual(doc1.isDestination)
 
     const doc2: AreaEditableFieldsType = {


### PR DESCRIPTION
---
name: Pull request
about: Create a pull request
title: Location or Approach field for Areas #1051
labels: feature
assignees: @mikeschen 

---

## What type of PR is this?(check all applicable)
- [ ] refactor
- [x] feature
- [ ] bug fix
- [ ] documentation
- [ ] optimization
- [ ] other

## Description
Adds ability for the backend to have a location for areas. We have description, but no way to enter a location.
**To Test:**
- Run `yarn serve-dev`
- go to [localhost:4000](http://localhost:4000/)
- Get a area
```
query Example1 {
  areas(filter: {area_name: {match: "Pencil Thin"}}) {
    uuid
    area_name
    content {
      description
      areaLocation
    }
  }
}
```
- Make mutation with UUID from query
```
mutation {
  updateArea(input: {
    uuid: "8caa09a1-fe90-523f-b99e-cf6cba39bdcc",
    areaLocation: "This is my New GPS Coordinates or Description",
    description: "I will Updated description too"
  }) {
    area_name
    content {
      areaLocation
      description
    }
  }
}
```
- Check on changes:
```
query Example1 {
  areas(filter: {area_name: {match: "Pencil Thin"}}) {
    uuid
    area_name
    content {
      description
      areaLocation
    }
  }
}
```

### Related Issues

Issue #
1051

### What this PR achieves
Adds ability for the backend to have a location for areas. 

### Screenshots, recordings

### Notes
<!--Anything in particular you want the reviewer pay attention to? This could be things that you are not sure about, or possible risks of your change.-->




