### PR TITLE
Pagination for area and climb media

### DIFF
--- a/src/__tests__/areas.ts
+++ b/src/__tests__/areas.ts
@@ -2,7 +2,9 @@ import { ApolloServer } from '@apollo/server'
 import muuid from 'uuid-mongodb'
 import { jest } from '@jest/globals'
 import MutableAreaDataSource from '../model/MutableAreaDataSource.js'
+import MutableMediaDataSource from '../model/MutableMediaDataSource.js'
 import MutableOrganizationDataSource from '../model/MutableOrganizationDataSource.js'
+import { MediaObjectGQLInput } from '../db/MediaObjectTypes.js'
 import { AreaType } from '../db/AreaTypes.js'
 import { OrganizationEditableFieldsType, OrganizationType, OrgType } from '../db/OrganizationTypes.js'
 import { queryAPI, setUpServer } from '../utils/testUtils.js'
@@ -47,6 +49,27 @@ describe('areas API', () => {
     await server.stop()
     await inMemoryDB.close()
   })
+
+  async function insertMediaObjectsForArea (areaId: string, mediaCount: number): Promise<void> {
+    const newMediaListInput: MediaObjectGQLInput[] = []
+    for (let i = 0; i < mediaCount; i++) {
+      newMediaListInput.push({
+        userUuid: 'a2eb6353-65d1-445f-912c-53c6301404bd',
+        width: 800,
+        height: 600,
+        format: 'jpeg',
+        size: 45000,
+        mediaUrl: `/areaPhoto${i}.jpg`,
+        entityTag: {
+          entityType: 1,
+          entityId: areaId
+        }
+      })
+    }
+
+    const media = MutableMediaDataSource.getInstance()
+    await media.addMediaObjects(newMediaListInput)
+  }
 
   describe('queries', () => {
     const areaQuery = `
@@ -106,5 +129,51 @@ describe('areas API', () => {
       expect(areaResult.organizations).toHaveLength(1)
       expect(areaResult.organizations[0].orgId).toBe(muuidToString(alphaOrg.orgId))
     })
+  })
+
+  it('returns paginated Media when requested', async () => {
+    await insertMediaObjectsForArea(usa.metadata.area_id.toString(), 11)
+
+    const areaQueryWithPaginatedMedia = `
+      query area($uuid: ID!, $input: EmbeddedAreaMediaInput) {
+        area(uuid: $uuid) {
+          mediaPagination(input: $input) {
+            areaUuid
+            mediaConnection {
+              edges {
+                node {
+                  id
+                  mediaUrl
+                }
+                cursor
+              }
+              pageInfo {
+                hasNextPage
+                totalItems
+                endCursor
+              }
+            }
+          }
+        }
+      }
+    `
+    const response = await queryAPI({
+      query: areaQueryWithPaginatedMedia,
+      operationName: 'area',
+      variables: {
+        uuid: usa.metadata.area_id,
+        input: {
+          first: 5,
+          after: null
+        }
+      },
+      userUuid,
+      app
+    })
+    expect(response.statusCode).toBe(200)
+    const areaResult = response.body.data.area
+    expect(areaResult.mediaPagination.mediaConnection.edges).toHaveLength(5)
+    expect(areaResult.mediaPagination.mediaConnection.pageInfo.totalItems).toBe(11)
+    expect(areaResult.mediaPagination.mediaConnection.pageInfo.hasNextPage).toBe(true)
   })
 })

--- a/src/db/MediaObjectTypes.ts
+++ b/src/db/MediaObjectTypes.ts
@@ -58,15 +58,30 @@ export interface TagsLeaderboardType {
  */
 export type NewMediaObjectDoc = Omit<MediaObject, '_id' | 'createdAt'>
 
-export interface UserMediaGQLQueryInput {
-  userUuid: string
+/**
+ * GQL input type for getting paginated media for an "Entity", which is either a user, an area, or a climb.
+ * The userUuid is omitted from the Area and Climb versions of this type, which are defined below
+ * as AreaMediaQueryInput and ClimbMediaQueryInput
+ * @param maxFiles - the maximum number of media files to return
+ * @param first - the number of media files to return
+ * @param after - the cursor to start from
+ */
+export interface EntityMediaGQLQueryInput {
   maxFiles?: number
   first?: number
   after?: string
 }
 
-export type UserMediaQueryInput = Omit<UserMediaGQLQueryInput, 'userUuid'> & {
+export type UserMediaQueryInput = EntityMediaGQLQueryInput & {
   userUuid: MUUID
+}
+
+export type AreaMediaQueryInput = EntityMediaGQLQueryInput & {
+  areaUuid: MUUID
+}
+
+export type ClimbMediaQueryInput = EntityMediaGQLQueryInput & {
+  climbUuid: MUUID
 }
 
 /**
@@ -121,6 +136,14 @@ export interface UserMedia {
       endCursor: string | null
     }
   }
+}
+
+export type AreaMedia = Omit<UserMedia, 'userUuid'> & {
+  areaUuid: string
+}
+
+export type ClimbMedia = Omit<UserMedia, 'userUuid'> & {
+  climbUuid: string
 }
 
 interface MediaEdge {

--- a/src/graphql/media/queries.ts
+++ b/src/graphql/media/queries.ts
@@ -1,6 +1,6 @@
 import mongoose from 'mongoose'
 import muuid from 'uuid-mongodb'
-import { TagsLeaderboardType, MediaObject, MediaByUsers, UserMediaGQLQueryInput, MediaForFeedInput } from '../../db/MediaObjectTypes.js'
+import { TagsLeaderboardType, MediaObject, MediaByUsers, UserMediaQueryInput, AreaMediaQueryInput, ClimbMediaQueryInput, MediaForFeedInput } from '../../db/MediaObjectTypes.js'
 import { GQLContext } from '../../types.js'
 
 const MediaQueries = {
@@ -19,14 +19,26 @@ const MediaQueries = {
 
   getUserMedia: async (_: any, { input }, { dataSources }: GQLContext): Promise<MediaObject[]> => {
     const { media } = dataSources
-    const { userUuid, maxFiles = 1000 } = input as UserMediaGQLQueryInput
-    return await media.getOneUserMedia(userUuid, maxFiles)
+    const { userUuid, maxFiles = 1000 } = input as UserMediaQueryInput
+    return await media.getOneUserMedia(userUuid.toString(), maxFiles)
   },
 
   getUserMediaPagination: async (_: any, { input }, { dataSources }: GQLContext): Promise<any> => {
     const { media } = dataSources
-    const { userUuid } = input as UserMediaGQLQueryInput
+    const { userUuid } = input as UserMediaQueryInput
     return await media.getOneUserMediaPagination({ ...input, userUuid: muuid.from(userUuid) })
+  },
+
+  areaMediaPagination: async (_: any, { input }, { dataSources }: GQLContext): Promise<any> => {
+    const { media } = dataSources
+    const { areaUuid } = input as AreaMediaQueryInput
+    return await media.getOneAreaMediaPagination({ ...input, areaUuid: muuid.from(areaUuid) })
+  },
+
+  climbMediaPagination: async (_: any, { input }, { dataSources }: GQLContext): Promise<any> => {
+    const { media } = dataSources
+    const { climbUuid } = input as ClimbMediaQueryInput
+    return await media.getOneClimbMediaPagination({ ...input, climbUuid: muuid.from(climbUuid) })
   },
 
   getTagsLeaderboard: async (_, { limit = 30 }: { limit: number }, { dataSources }: GQLContext): Promise<TagsLeaderboardType> => {

--- a/src/graphql/resolvers.ts
+++ b/src/graphql/resolvers.ts
@@ -10,6 +10,7 @@ import { HistoryFieldResolvers, HistoryQueries } from '../graphql/history/index.
 import { GQLContext, GQLFilter, QueryByIdType, Sort } from '../types'
 import { AreaType, CountByDisciplineType } from '../db/AreaTypes.js'
 import { ClimbGQLQueryType, ClimbType } from '../db/ClimbTypes.js'
+import { EntityMediaGQLQueryInput } from '../db/MediaObjectTypes.js'
 import AreaDataSource from '../model/AreaDataSource.js'
 import { MediaMutations, MediaQueries, MediaResolvers } from './media/index.js'
 import { AreaMutations, AreaQueries } from './area/index.js'
@@ -181,6 +182,11 @@ const resolvers = {
       return await media.findMediaByClimbId(node._id, node.name)
     },
 
+    mediaPagination: async (node: ClimbType, { input }: { input: EntityMediaGQLQueryInput }, { dataSources }: GQLContext) => {
+      const { media } = dataSources
+      return await media.getOneClimbMediaPagination({ ...input, climbUuid: node._id })
+    },
+
     content: (node: ClimbGQLQueryType) => node.content == null
       ? {
           description: '',
@@ -262,6 +268,11 @@ const resolvers = {
     media: async (node: any, args: any, { dataSources }: GQLContext) => {
       const { media } = dataSources
       return await media.findMediaByAreaId(node.metadata.area_id, null)
+    },
+
+    mediaPagination: async (node: AreaType, { input }: { input: EntityMediaGQLQueryInput }, { dataSources }: GQLContext) => {
+      const { media } = dataSources
+      return await media.getOneAreaMediaPagination({ ...input, areaUuid: node.metadata.area_id })
     },
 
     authorMetadata: getAuthorMetadataFromBaseNode,

--- a/src/graphql/schema/Area.gql
+++ b/src/graphql/schema/Area.gql
@@ -66,11 +66,27 @@ type Area {
   totalClimbs: Int!
   "Media associated with this area, or its child climbs"
   media: [MediaWithTags]
+  "Paginated media for this area"
+  mediaPagination(input: EmbeddedAreaMediaInput): AreaMedia
   "Metadata about creation & update of this area"
   authorMetadata: AuthorMetadata!
   "Organizations associated with this area or its parent areas"
   organizations: [Organization]
 }
+
+"""
+This EmbeddedAreaMediaInput is different from the AreaMediaInput in Media.gql because we don't need to
+include the areaUuid (which is required over in the paginated Media query). Here in the area query,
+the areaUuid is already included in top level of the query
+"""
+input EmbeddedAreaMediaInput {
+  "Max number of objects return.  Ignore when using with pagination query."
+  maxFiles: Int
+  "Number of objects per page (Default = 6)."
+  first: Int
+  "Returning page data after this cursor (exclusive).  Return the first page if omitted."
+  after: ID
+ }
 
 type AreaMetadata {
   isDestination: Boolean!

--- a/src/graphql/schema/Climb.gql
+++ b/src/graphql/schema/Climb.gql
@@ -60,6 +60,9 @@ type Climb {
   "Media associated with this climb"
   media: [MediaWithTags]
 
+  "Paginated media for this climb"
+  mediaPagination(input: EmbeddedClimbMediaInput): ClimbMedia
+
   yds: String @deprecated(reason: "Migrating to 'grades' field")
 
   "The parent area object"
@@ -71,6 +74,20 @@ type Climb {
   "User ticks of this climb"
   ticks: [TickType]
 }
+
+"""
+This EmbeddedClimbMediaInput is different from the ClimbMediaInput in Media.gql because we don't need to
+include the climbUuid (which is required over in the paginated Media query). Here in the climb query,
+the climbUuid is already included in top level of the query.
+"""
+input EmbeddedClimbMediaInput {
+  "Max number of objects return.  Ignore when using with pagination query."
+  maxFiles: Int
+  "Number of objects per page (Default = 6)."
+  first: Int
+  "Returning page data after this cursor (exclusive).  Return the first page if omitted."
+  after: ID
+ }
 
 type ClimbMetadata {
   lat: Float

--- a/src/graphql/schema/Media.gql
+++ b/src/graphql/schema/Media.gql
@@ -49,6 +49,16 @@ type Query {
   getUserMediaPagination(input: UserMediaInput): UserMedia
 
   """
+  Get media cursor with paginationg for an area
+  """
+  areaMediaPagination(input: AreaMediaInput): AreaMedia
+
+  """
+  Get media cursor with paginationg for a climb
+  """
+  climbMediaPagination(input: ClimbMediaInput): ClimbMedia
+
+  """
   Get a list of users and their tagged photo count.
   """
   getTagsLeaderboard(limit: Int): TagsLeaderboard
@@ -60,6 +70,24 @@ See https://graphql.org/learn/pagination/
 """
 type UserMedia {
   userUuid: ID!
+  mediaConnection: MediaConnection!
+}
+
+"""
+Area media cursor with pagination support.
+See https://graphql.org/learn/pagination/
+"""
+type AreaMedia {
+  areaUuid: ID!
+  mediaConnection: MediaConnection!
+}
+
+"""
+Climb media cursor with pagination support.
+See https://graphql.org/learn/pagination/
+"""
+type ClimbMedia {
+  climbUuid: ID!
   mediaConnection: MediaConnection!
 }
 
@@ -230,6 +258,29 @@ input UserMediaInput {
   after: ID
 }
 
+"Input parameters for area and climb media queries."
+input AreaMediaInput {
+  "Area UUID   Ex: 5f5b4b4b-0b3b-4b3b-8b3b-7b3b2b3b2b3b"
+  areaUuid: ID!
+  "Max number of objects return.  Ignore when using with pagination query."
+  maxFiles: Int
+  "Number of objects per page (Default = 6)."
+  first: Int
+  "Returning page data after this cursor (exclusive).  Return the first page if omitted."
+  after: ID
+}
+
+"Input parameters for climb media queries."
+input ClimbMediaInput {
+  "Climb UUID   Ex: 5f5b4b4b-0b3b-4b3b-8b3b-7b3b2b3b2b3b"
+  climbUuid: ID!
+  "Max number of objects return.  Ignore when using with pagination query."
+  maxFiles: Int
+  "Number of objects per page (Default = 6)."
+  first: Int
+  "Returning page data after this cursor (exclusive).  Return the first page if omitted."
+  after: ID
+}
 input MediaForFeedInput {
   maxUsers: Int
   maxFiles: Int

--- a/src/model/MediaDataSource.ts
+++ b/src/model/MediaDataSource.ts
@@ -3,7 +3,7 @@ import muid, { MUUID } from 'uuid-mongodb'
 import mongoose from 'mongoose'
 import { logger } from '../logger.js'
 import { getMediaObjectModel } from '../db/index.js'
-import { TagsLeaderboardType, UserMediaQueryInput, AllTimeTagStats, MediaByUsers, MediaForFeedInput, MediaObject, UserMedia } from '../db/MediaObjectTypes.js'
+import { TagsLeaderboardType, UserMediaQueryInput, AreaMediaQueryInput, ClimbMediaQueryInput, AllTimeTagStats, MediaByUsers, MediaForFeedInput, MediaObject, UserMedia, AreaMedia, ClimbMedia } from '../db/MediaObjectTypes.js'
 
 const HARD_MAX_FILES = 1000
 const HARD_MAX_USERS = 100
@@ -123,75 +123,67 @@ export default class MediaDataSource extends MongoDataSource<MediaObject> {
    * - https://www.mixmax.com/engineering/api-paging-built-the-right-way
    * - https://graphql.org/learn/pagination/
    * @param input
-   * @returns
+   * @returns array of UserMedia
    */
   async getOneUserMediaPagination (input: UserMediaQueryInput): Promise<UserMedia> {
     const { userUuid, first = 6, after } = input
-    let nextCreatedDate: number
-    let nextId: mongoose.Types.ObjectId
-    let filters: any
-    if (after != null) {
-      const d = after.split('_')
-      nextCreatedDate = Number.parseInt(d[0])
-      nextId = new mongoose.Types.ObjectId(d[1])
-      filters = {
-        $match: {
-          $and: [
-            { userUuid },
-            {
-              $or: [{
-                createdAt: { $lt: new Date(nextCreatedDate) }
-              },
-              {
-                // If the created date is an exact match, we need a tiebreaker,
-                // so we use the _id field from the cursor.
-                createdAt: new Date(nextCreatedDate),
-                _id: { $lt: nextId }
-              }
-              ]
-            }
-          ]
-        }
-      }
-    } else {
-      filters = { $match: { userUuid } }
-    }
-
-    const rs = await this.mediaObjectModel.aggregate<MediaObject>([
-      filters,
-      {
-        $sort: { createdAt: -1, _id: -1 }
-      },
-      {
-        $limit: first + 1 // fetch 1 extra to see if there's a next page
-      }
-    ])
-
-    const itemCount = await this.mediaObjectModel.countDocuments({ userUuid })
-
+    const filters = this.mediaFilters(after, userUuid, 'user')
+    const filteredMedia = await this.aggregateMedia(filters, first)
+    const itemCount = await this.mediaObjectModel.countDocuments(this.getMatchClause(userUuid, 'user'))
     let hasNextPage = false
-    if (rs.length > first) {
+    if (filteredMedia.length > first) {
       // ok there's a next page. remove the extra item.
-      rs.pop()
+      filteredMedia.pop()
       hasNextPage = true
     }
 
     return {
       userUuid: userUuid.toUUID().toString(),
-      mediaConnection: {
-        edges: rs.map(node => (
-          {
-            node,
-            cursor: `${node.createdAt.getTime()}_${node._id.toString()}`
-          }
-        )),
-        pageInfo: {
-          hasNextPage,
-          totalItems: itemCount,
-          endCursor: null
-        }
+      mediaConnection: this.getMediaConnection(filteredMedia, itemCount, hasNextPage)
+    }
+  }
 
-      }
+  /**
+   * Get Area media by page.
+   * @param input
+   * @returns array of AreaMedia
+   */
+  async getOneAreaMediaPagination (input: AreaMediaQueryInput): Promise<AreaMedia> {
+    const { areaUuid, first = 6, after } = input
+    const filters = this.mediaFilters(after, areaUuid, 'area')
+    const filteredMedia = await this.aggregateMedia(filters, first)
+    const itemCount = await this.mediaObjectModel.countDocuments(this.getMatchClause(areaUuid, 'area'))
+    let hasNextPage = false
+    if (filteredMedia.length > first) {
+      filteredMedia.pop()
+      hasNextPage = true
+    }
+
+    return {
+      areaUuid: areaUuid.toUUID().toString(),
+      mediaConnection: this.getMediaConnection(filteredMedia, itemCount, hasNextPage)
+    }
+  }
+
+  /**
+   * Get Climb media by page.
+   * @param input
+   * @returns array of ClimbMedia
+   */
+  async getOneClimbMediaPagination (input: ClimbMediaQueryInput): Promise<ClimbMedia> {
+    const { climbUuid, first = 6, after } = input
+    const filters = this.mediaFilters(after, climbUuid, 'climb')
+    const filteredMedia = await this.aggregateMedia(filters, first)
+    const itemCount = await this.mediaObjectModel.countDocuments(this.getMatchClause(climbUuid, 'climb'))
+    let hasNextPage = false
+    if (filteredMedia.length > first) {
+      filteredMedia.pop()
+      hasNextPage = true
+    }
+
+    return {
+      climbUuid: climbUuid.toUUID().toString(),
+      mediaConnection: this.getMediaConnection(filteredMedia, itemCount, hasNextPage)
     }
   }
 
@@ -270,7 +262,7 @@ export default class MediaDataSource extends MongoDataSource<MediaObject> {
    *
    * @param areaId
    * @param ancestors
-   * @returns `UserMediaWithTags` array
+   * @returns `MediaWithTags` array
    */
   async findMediaByAreaId (areaId: MUUID, projection: any, shouldConvertUuidToString = false): Promise<MediaObject[]> {
     const transformFn = (doc: MediaObject): any => {
@@ -303,5 +295,83 @@ export default class MediaDataSource extends MongoDataSource<MediaObject> {
      */
     const doc = await this.mediaObjectModel.find({ _id, userUuid }, { _id: 1 }).lean()
     return doc != null
+  }
+
+  /**
+   * helper functions for quering media objects by user, area, or climb. Each query has slightly different syntax,
+   * so these private functions return the appropriate filter for the query.
+   * @param entityUuid area, climb or user uuid
+   * @param entityType 'area', 'climb', or 'user'
+   * @returns
+   */
+
+  private mediaFilters (after: string | undefined, entityUuid: MUUID, entityType: string): any {
+    let nextCreatedDate: number
+    let nextId: mongoose.Types.ObjectId
+    let filters: any
+    const matchClause = this.getMatchClause(entityUuid, entityType)
+
+    if (after != null) {
+      const d = after.split('_')
+      nextCreatedDate = Number.parseInt(d[0])
+      nextId = new mongoose.Types.ObjectId(d[1])
+      filters = {
+        $match: {
+          $and: [
+            matchClause,
+            {
+              $or: [{
+                createdAt: { $lt: new Date(nextCreatedDate) }
+              },
+              {
+                // If the created date is an exact match, we need a tiebreaker,
+                // so we use the _id field from the cursor.
+                createdAt: new Date(nextCreatedDate),
+                _id: { $lt: nextId }
+              }
+              ]
+            }
+          ]
+        }
+      }
+    } else {
+      filters = { $match: matchClause }
+    }
+    return filters
+  }
+
+  private getMatchClause (entityUuid: MUUID, entityType: string): any {
+    if (entityType === 'user') {
+      return { userUuid: entityUuid }
+    } else if (entityType === 'area') {
+      return { 'entityTags.ancestors': { $regex: entityUuid.toUUID().toString() } }
+    } else if (entityType === 'climb') {
+      return { 'entityTags.targetId': entityUuid }
+    }
+    throw new Error(`Unexpected entity type: ${entityType}`)
+  }
+
+  private async aggregateMedia (filters: any, first: number): Promise<MediaObject[]> {
+    return await this.mediaObjectModel.aggregate<MediaObject>([
+      filters,
+      { $sort: { createdAt: -1, _id: -1 } },
+      { $limit: first + 1 } // fetch 1 extra to see if there's a next page
+    ])
+  }
+
+  private getMediaConnection (filteredMedia: MediaObject[], itemCount: number, hasNextPage: boolean): any {
+    return {
+      edges: filteredMedia.map(node => (
+        {
+          node,
+          cursor: `${node.createdAt.getTime()}_${node._id.toString()}`
+        }
+      )),
+      pageInfo: {
+        hasNextPage,
+        totalItems: itemCount,
+        endCursor: null
+      }
+    }
   }
 }

--- a/src/model/__tests__/MediaDataSource.ts
+++ b/src/model/__tests__/MediaDataSource.ts
@@ -247,7 +247,7 @@ describe('MediaDataSource', () => {
 
     const page1 = await media.getOneUserMediaPagination(input)
 
-    verifyPageData(page1, MEDIA_TEMPLATE.userUuid, expectedMedia.slice(0, 3), mediaCount, ITEMS_PER_PAGE, true)
+    verifyPageData(page1, MEDIA_TEMPLATE.userUuid, 'userUuid', expectedMedia.slice(0, 3), mediaCount, ITEMS_PER_PAGE, true)
 
     const page1Edges = page1.mediaConnection.edges
     const input2: UserMediaQueryInput = {
@@ -257,7 +257,7 @@ describe('MediaDataSource', () => {
     }
     const page2 = await media.getOneUserMediaPagination(input2)
 
-    verifyPageData(page2, MEDIA_TEMPLATE.userUuid, expectedMedia.slice(3, 6), mediaCount, ITEMS_PER_PAGE, true)
+    verifyPageData(page2, MEDIA_TEMPLATE.userUuid, 'userUuid', expectedMedia.slice(3, 6), mediaCount, ITEMS_PER_PAGE, true)
 
     const page2Edges = page2.mediaConnection.edges
     const input3: UserMediaQueryInput = {
@@ -267,7 +267,7 @@ describe('MediaDataSource', () => {
     }
     const page3 = await media.getOneUserMediaPagination(input3)
 
-    verifyPageData(page3, MEDIA_TEMPLATE.userUuid, expectedMedia.slice(6, 7), mediaCount, 1, false)
+    verifyPageData(page3, MEDIA_TEMPLATE.userUuid, 'userUuid', expectedMedia.slice(6, 7), mediaCount, 1, false)
   })
 
   it('should return paginated area media results', async () => {
@@ -310,7 +310,7 @@ describe('MediaDataSource', () => {
 
     const page1 = await media.getOneAreaMediaPagination(input)
 
-    verifyPageData(page1, areaForTagging3.metadata.area_id.toString(), expectedMedia.slice(0, 3), mediaCount, ITEMS_PER_PAGE, true)
+    verifyPageData(page1, areaForTagging3.metadata.area_id.toString(), 'areaUuid', expectedMedia.slice(0, 3), mediaCount, ITEMS_PER_PAGE, true)
 
     const page1Edges = page1.mediaConnection.edges
     const input2: AreaMediaQueryInput = {
@@ -320,7 +320,7 @@ describe('MediaDataSource', () => {
     }
     const page2 = await media.getOneAreaMediaPagination(input2)
 
-    verifyPageData(page2, areaForTagging3.metadata.area_id.toString(), expectedMedia.slice(3, 6), mediaCount, ITEMS_PER_PAGE, true)
+    verifyPageData(page2, areaForTagging3.metadata.area_id.toString(), 'areaUuid', expectedMedia.slice(3, 6), mediaCount, ITEMS_PER_PAGE, true)
 
     const page2Edges = page2.mediaConnection.edges
     const input3: AreaMediaQueryInput = {
@@ -330,7 +330,7 @@ describe('MediaDataSource', () => {
     }
     const page3 = await media.getOneAreaMediaPagination(input3)
 
-    verifyPageData(page3, areaForTagging3.metadata.area_id.toString(), expectedMedia.slice(6, 7), mediaCount, 1, false)
+    verifyPageData(page3, areaForTagging3.metadata.area_id.toString(), 'areaUuid', expectedMedia.slice(6, 7), mediaCount, 1, false)
   })
 
   it('should return paginated climb media results', async () => {
@@ -373,7 +373,7 @@ describe('MediaDataSource', () => {
 
     const page1 = await media.getOneClimbMediaPagination(input)
 
-    verifyPageData(page1, climbIdForTagging.toString(), expectedMedia.slice(0, 4), mediaCount, ITEMS_PER_PAGE, true)
+    verifyPageData(page1, climbIdForTagging.toString(), 'climbUuid', expectedMedia.slice(0, 4), mediaCount, ITEMS_PER_PAGE, true)
 
     const page1Edges = page1.mediaConnection.edges
     const input2: ClimbMediaQueryInput = {
@@ -383,7 +383,7 @@ describe('MediaDataSource', () => {
     }
     const page2 = await media.getOneClimbMediaPagination(input2)
 
-    verifyPageData(page2, climbIdForTagging.toString(), expectedMedia.slice(4, 8), mediaCount, ITEMS_PER_PAGE, true)
+    verifyPageData(page2, climbIdForTagging.toString(), 'climbUuid', expectedMedia.slice(4, 8), mediaCount, ITEMS_PER_PAGE, true)
 
     const page2Edges = page2.mediaConnection.edges
     const input3: ClimbMediaQueryInput = {
@@ -393,7 +393,7 @@ describe('MediaDataSource', () => {
     }
     const page3 = await media.getOneClimbMediaPagination(input3)
 
-    verifyPageData(page3, climbIdForTagging.toString(), expectedMedia.slice(8, 11), mediaCount, 3, false)
+    verifyPageData(page3, climbIdForTagging.toString(), 'climbUuid', expectedMedia.slice(8, 11), mediaCount, 3, false)
   })
 })
 
@@ -401,18 +401,27 @@ describe('MediaDataSource', () => {
  * Verify media page data
  * @param actualPage
  * @param expectedUuid
+ * @param expectedUuidType "userUuid" | "areaUuid" | "climbUuid"
  * @param expectedMedia
  * @param totalItems
  * @param itemsPerPage
  * @param hasNextPage
  */
 const verifyPageData = (
-  actualPage: { mediaConnection: any },
+  actualPage: any,
   expectedUuid: string,
+  expectedUuidType: string,
   expectedMedia: MediaObject[],
   totalItems: number,
   itemsPerPage: number,
   hasNextPage: boolean): void => {
+  if (expectedUuidType === 'userUuid') {
+    expect(actualPage.userUuid).toEqual(expectedUuid)
+  } else if (expectedUuidType === 'areaUuid') {
+    expect(actualPage.areaUuid).toEqual(expectedUuid)
+  } else if (expectedUuidType === 'climbUuid') {
+    expect(actualPage.climbUuid).toEqual(expectedUuid)
+  }
   expect(actualPage.mediaConnection.pageInfo.hasNextPage).toStrictEqual(hasNextPage)
   expect(actualPage.mediaConnection.pageInfo.totalItems).toStrictEqual(totalItems)
   const pageEdges = actualPage.mediaConnection.edges

--- a/src/model/__tests__/MediaDataSource.ts
+++ b/src/model/__tests__/MediaDataSource.ts
@@ -11,8 +11,9 @@ import {
   EntityTag,
   MediaObject,
   MediaObjectGQLInput,
-  UserMedia,
-  UserMediaQueryInput
+  UserMediaQueryInput,
+  AreaMediaQueryInput,
+  ClimbMediaQueryInput
 } from '../../db/MediaObjectTypes.js'
 import { newSportClimb1 } from './MutableClimbDataSource.js'
 import inMemoryDB from '../../utils/inMemoryDB.js'
@@ -33,6 +34,7 @@ describe('MediaDataSource', () => {
 
   let areaForTagging1: AreaType
   let areaForTagging2: AreaType
+  let areaForTagging3: AreaType
   let climbIdForTagging: MUUID
 
   let areaTag1: AddTagEntityInput
@@ -47,7 +49,9 @@ describe('MediaDataSource', () => {
     areas = AreaDataSource.getInstance()
     climbs = ClimbDataSource.getInstance()
     media = MutableMediaDataSource.getInstance()
+  })
 
+  beforeEach(async () => {
     try {
       await areas.areaModel.collection.drop()
       await climbs.climbModel.collection.drop()
@@ -61,7 +65,8 @@ describe('MediaDataSource', () => {
     await areas.addCountry('USA')
     areaForTagging1 = await areas.addArea(muuid.v4(), 'Yosemite NP', null, 'USA')
     areaForTagging2 = await areas.addArea(muuid.v4(), 'Lake Tahoe', null, 'USA')
-    if (areaForTagging1 == null || areaForTagging2 == null) fail('Fail to pre-seed test areas')
+    areaForTagging3 = await areas.addArea(muuid.v4(), 'Shelf Road', null, 'USA')
+    if (areaForTagging1 == null || areaForTagging2 == null || areaForTagging3 == null) fail('Fail to pre-seed test areas')
 
     const rs = await climbs.addOrUpdateClimbs(muuid.v4(), areaForTagging1.metadata.area_id, [newSportClimb1])
     if (rs == null) fail('Fail to pre-seed test climbs')
@@ -209,7 +214,7 @@ describe('MediaDataSource', () => {
     await expect(media.deleteMediaObject(rs[0]._id)).rejects.toThrowError(/Cannot delete media object with non-empty tags./i)
   })
 
-  it('should return paginated media results', async () => {
+  it('should return paginated user media results', async () => {
     const ITEMS_PER_PAGE = 3
     const MEDIA_TEMPLATE: MediaObjectGQLInput = {
       ...TEST_MEDIA,
@@ -264,25 +269,150 @@ describe('MediaDataSource', () => {
 
     verifyPageData(page3, MEDIA_TEMPLATE.userUuid, expectedMedia.slice(6, 7), mediaCount, 1, false)
   })
+
+  it('should return paginated area media results', async () => {
+    const ITEMS_PER_PAGE = 3
+    const MEDIA_TEMPLATE: MediaObjectGQLInput = {
+      ...TEST_MEDIA,
+      userUuid: 'a0ca9ebb-aa3b-4bb0-8ddd-7c8b2ed228a6'
+    }
+
+    /**
+     * Let's insert 7 media objects with the appropriate areaId in entityTags.
+     * With 3 items per page we should expect 3 pages.
+     */
+    const newMediaListInput: MediaObjectGQLInput[] = []
+    const mediaCount = 7
+    for (let i = 0; i < mediaCount; i = i + 1) {
+      newMediaListInput.push({
+        ...MEDIA_TEMPLATE,
+        mediaUrl: `/areaPhoto${i}.jpg`,
+        entityTag: {
+          entityType: 1,
+          entityId: areaForTagging3.metadata.area_id.toUUID().toString()
+        }
+      })
+    }
+
+    const expectedMedia = await media.addMediaObjects(newMediaListInput)
+
+    if (expectedMedia == null) {
+      fail('Seeding test media fail')
+    }
+
+    // reverse because getOneAreaMediaPagination() returns most recent first
+    expectedMedia.reverse()
+
+    const input: AreaMediaQueryInput = {
+      areaUuid: muuid.from(areaForTagging3.metadata.area_id),
+      first: ITEMS_PER_PAGE
+    }
+
+    const page1 = await media.getOneAreaMediaPagination(input)
+
+    verifyPageData(page1, areaForTagging3.metadata.area_id.toString(), expectedMedia.slice(0, 3), mediaCount, ITEMS_PER_PAGE, true)
+
+    const page1Edges = page1.mediaConnection.edges
+    const input2: AreaMediaQueryInput = {
+      areaUuid: muuid.from(areaForTagging3.metadata.area_id),
+      first: ITEMS_PER_PAGE,
+      after: page1Edges[page1Edges.length - 1].cursor
+    }
+    const page2 = await media.getOneAreaMediaPagination(input2)
+
+    verifyPageData(page2, areaForTagging3.metadata.area_id.toString(), expectedMedia.slice(3, 6), mediaCount, ITEMS_PER_PAGE, true)
+
+    const page2Edges = page2.mediaConnection.edges
+    const input3: AreaMediaQueryInput = {
+      areaUuid: muuid.from(areaForTagging3.metadata.area_id),
+      first: ITEMS_PER_PAGE,
+      after: page2Edges[page2Edges.length - 1].cursor
+    }
+    const page3 = await media.getOneAreaMediaPagination(input3)
+
+    verifyPageData(page3, areaForTagging3.metadata.area_id.toString(), expectedMedia.slice(6, 7), mediaCount, 1, false)
+  })
+
+  it('should return paginated climb media results', async () => {
+    const ITEMS_PER_PAGE = 4
+    const MEDIA_TEMPLATE: MediaObjectGQLInput = {
+      ...TEST_MEDIA,
+      userUuid: 'a0ca9ebb-aa3b-4bb0-8ddd-7c8b2ed228a7'
+    }
+
+    /**
+     * insert 11 media objects with the appropriate climbId in entityTags.
+     * With 4 items per page we should expect 3 pages.
+     */
+    const newMediaListInput: MediaObjectGQLInput[] = []
+    const mediaCount = 11
+    for (let i = 0; i < mediaCount; i = i + 1) {
+      newMediaListInput.push({
+        ...MEDIA_TEMPLATE,
+        mediaUrl: `/climbPhoto${i}.jpg`,
+        entityTag: {
+          entityType: 0,
+          entityId: climbIdForTagging.toUUID().toString()
+        }
+      })
+    }
+
+    const expectedMedia = await media.addMediaObjects(newMediaListInput)
+
+    if (expectedMedia == null) {
+      fail('Seeding test media fail')
+    }
+
+    // reverse because getOneClimbMediaPagination() returns most recent first
+    expectedMedia.reverse()
+
+    const input: ClimbMediaQueryInput = {
+      climbUuid: muuid.from(climbIdForTagging),
+      first: ITEMS_PER_PAGE
+    }
+
+    const page1 = await media.getOneClimbMediaPagination(input)
+
+    verifyPageData(page1, climbIdForTagging.toString(), expectedMedia.slice(0, 4), mediaCount, ITEMS_PER_PAGE, true)
+
+    const page1Edges = page1.mediaConnection.edges
+    const input2: ClimbMediaQueryInput = {
+      climbUuid: muuid.from(climbIdForTagging),
+      first: ITEMS_PER_PAGE,
+      after: page1Edges[page1Edges.length - 1].cursor
+    }
+    const page2 = await media.getOneClimbMediaPagination(input2)
+
+    verifyPageData(page2, climbIdForTagging.toString(), expectedMedia.slice(4, 8), mediaCount, ITEMS_PER_PAGE, true)
+
+    const page2Edges = page2.mediaConnection.edges
+    const input3: ClimbMediaQueryInput = {
+      climbUuid: muuid.from(climbIdForTagging),
+      first: ITEMS_PER_PAGE,
+      after: page2Edges[page2Edges.length - 1].cursor
+    }
+    const page3 = await media.getOneClimbMediaPagination(input3)
+
+    verifyPageData(page3, climbIdForTagging.toString(), expectedMedia.slice(8, 11), mediaCount, 3, false)
+  })
 })
 
 /**
  * Verify media page data
  * @param actualPage
- * @param expectedUserUuid
+ * @param expectedUuid
  * @param expectedMedia
  * @param totalItems
  * @param itemsPerPage
  * @param hasNextPage
  */
 const verifyPageData = (
-  actualPage: UserMedia,
-  expectedUserUuid: string,
+  actualPage: { mediaConnection: any },
+  expectedUuid: string,
   expectedMedia: MediaObject[],
   totalItems: number,
   itemsPerPage: number,
   hasNextPage: boolean): void => {
-  expect(actualPage.userUuid).toEqual(expectedUserUuid)
   expect(actualPage.mediaConnection.pageInfo.hasNextPage).toStrictEqual(hasNextPage)
   expect(actualPage.mediaConnection.pageInfo.totalItems).toStrictEqual(totalItems)
   const pageEdges = actualPage.mediaConnection.edges


### PR DESCRIPTION
Add query endpoints for `areaMediaPagination` and `climbMediaPagination`

For each query, the uuid is required (`climbUuid` or `areaUuid`), and the other pagination options `after`, `first`,  and `maxFiles`

Returns the uuid (climb or area), and a `mediaConnection`, with the same structure as the `getUserMediaPagination` endpoint, including totalItems.

Technical details:
For queuing areas/climbs with lots of media (eg, the entire US), this _should_ be efficient and fairly fast.
We only query the number of media objects + 1 requested with `first` (defaults to 6), so we aren't loading all the media objects into memory. We use `countDocuments` to efficiently get the totalItems.

Testing performance locally is difficult as i don't currently have an efficient way to add lots and lots of media.

will it be possible to deploy this to staging and performance test there before pushing to production?
@vnugent @Vichy97 


![Screenshot 2025-02-17 at 2 08 28 PM](https://github.com/user-attachments/assets/4b8d49cf-f76e-47ec-a0bc-afddc7ee0f64)
![Screenshot 2025-02-17 at 2 09 00 PM](https://github.com/user-attachments/assets/565055c1-df90-4fec-898d-557e053d58b2)
