### PR TITLE
feat: add Repeat option for ticks

### DIFF
--- a/documentation/tick_logic.md
+++ b/documentation/tick_logic.md
@@ -27,7 +27,7 @@ Here are all the possible values for `Climb.type` (also called discipline), as d
 | snow          | Aid        | Send             |
 | ice           | Boulder    | Attempt          |
 | aid           |            | Frenchfree       |
-| tr            |            |                  |
+| tr            |            | Repeat           |
 | alpine        |            |                  |
 | mixed         |            |                  |
 
@@ -55,10 +55,10 @@ Since a route can have multiple disciplines, these options are composable. eg: a
 
 | Tick Style | Attempt Type options |
 |------------|----------------------|
-| 'Lead' | 'Onsight', 'Flash', 'Redpoint', 'Pinkpoint', 'Attempt', 'Frenchfree' |
+| 'Lead' | 'Onsight', 'Flash', 'Redpoint', 'Pinkpoint', 'Attempt', 'Frenchfree', 'Repeat' |
 | 'Follow', 'TR' or 'Aid | 'Send', 'Attempt' |
-| 'Solo' | 'Onsight', 'Flash', 'Redpoint', 'Attempt' |
-| 'Boulder' | 'Flash', 'Send', 'Attempt' |
+| 'Solo' | 'Onsight', 'Flash', 'Redpoint', 'Attempt', 'Repeat' |
+| 'Boulder' | 'Flash', 'Send', 'Attempt', 'Repeat' |
 
 ## A few justifications
 
@@ -68,6 +68,7 @@ Since a route can have multiple disciplines, these options are composable. eg: a
 * While 'Frenchfree' and 'Aid' could be considered synomonous, some climbers may want to distinguish, for example, a multipitch route where one pitch was intentionally 'French freed' (Time Wave Zero being a common example), which is distinctly different in character than, eg: aiding the Nose on El Cap.
 * Eventually, it might be cool to allow ticks for individual pitches, but that is not supported right now.
 * Given the 43,008 possible combinations, no simple logical system will perfectly capture every edge case.
+* Repeats: routes can be "repeated" after they are sent. this generally only applies if you have previously sent a route or boulder cleanly, and you send the route/boulder again cleanly. This is not typically used, for example, to mark additional attempts on a route that you haven't cleanly sent yet (one would use "attempt" for that). The only `Tick Style`s, for which `Repeat` is not allowed is `Follow` `TR` and `Aid`. While aid routes may be repeated, this is a rare enough use case and simplifies the logic in the code. 
 
 
 ## Importing from Mountain Project

--- a/src/db/TickSchema.ts
+++ b/src/db/TickSchema.ts
@@ -17,7 +17,7 @@ export const TickSchema = new Schema<TickType>({
   climbId: { type: Schema.Types.String, required: true, index: true },
   userId: { type: Schema.Types.String, required: true, index: true },
   style: { type: Schema.Types.String, enum: ['Lead', 'Solo', 'TR', 'Follow', 'Aid', 'Boulder'], required: false },
-  attemptType: { type: Schema.Types.String, enum: ['Onsight', 'Flash', 'Pinkpoint', 'Frenchfree', 'Redpoint', 'Send', 'Attempt'], required: false, index: true },
+  attemptType: { type: Schema.Types.String, enum: ['Onsight', 'Flash', 'Pinkpoint', 'Frenchfree', 'Redpoint', 'Send', 'Attempt', 'Repeat'], required: false, index: true },
   dateClimbed: { type: Schema.Types.Date },
   grade: { type: Schema.Types.String, required: false, index: true },
   // Bear in mind that these enum types must be kept in sync with the TickSource enum

--- a/src/db/TickTypes.ts
+++ b/src/db/TickTypes.ts
@@ -17,11 +17,11 @@ export type TickSource =
   'MP'
 
 export type TickStyle = 'Lead' | 'Solo' | 'TR' | 'Follow' | 'Aid' | 'Boulder'
-export type TickAttemptType = 'Onsight' | 'Flash' | 'Pinkpoint' | 'Frenchfree' | 'Send' | 'Attempt' | 'Redpoint'
+export type TickAttemptType = 'Onsight' | 'Flash' | 'Pinkpoint' | 'Frenchfree' | 'Send' | 'Attempt' | 'Redpoint' | 'Repeat'
 
 export const TickSourceValues: TickSource[] = ['OB', 'MP']
 export const TickStyleValues: TickStyle[] = ['Lead', 'Solo', 'TR', 'Follow', 'Aid', 'Boulder']
-export const TickAttemptTypeValues: TickAttemptType[] = ['Onsight', 'Flash', 'Pinkpoint', 'Frenchfree', 'Send', 'Attempt', 'Redpoint']
+export const TickAttemptTypeValues: TickAttemptType[] = ['Onsight', 'Flash', 'Pinkpoint', 'Frenchfree', 'Send', 'Attempt', 'Redpoint', 'Repeat']
 
 /** Ticks
  * Ticks represent log entries for a user's climbing activity. They contain

--- a/src/graphql/schema/Tick.gql
+++ b/src/graphql/schema/Tick.gql
@@ -136,6 +136,8 @@ enum TickAttemptType {
   Send
   "Redpoint"
   Redpoint
+  "Repeat"
+  Repeat
 }
 
 enum TickStyle {

--- a/src/model/TickDataSource.ts
+++ b/src/model/TickDataSource.ts
@@ -118,17 +118,17 @@ export default class TickDataSource extends MongoDataSource<TickType> {
     // validate attempt type for each tick style
     switch (tickStyle) {
       case 'Lead':
-        if (!['Onsight', 'Flash', 'Redpoint', 'Pinkpoint', 'Attempt', 'Frenchfree', 'null'].includes(attemptType)) {
+        if (!['Onsight', 'Flash', 'Redpoint', 'Pinkpoint', 'Attempt', 'Frenchfree', 'Repeat', 'null'].includes(attemptType)) {
           throw new Error(`Invalid attempt type ${attemptType} for Lead style`)
         }
         break
       case 'Solo':
-        if (!['Onsight', 'Flash', 'Redpoint', 'Attempt', 'null'].includes(attemptType)) {
+        if (!['Onsight', 'Flash', 'Redpoint', 'Attempt', 'Repeat', 'null'].includes(attemptType)) {
           throw new Error(`Invalid attempt type ${attemptType} for Solo style`)
         }
         break
       case 'Boulder':
-        if (!['Flash', 'Send', 'Attempt', 'null'].includes(attemptType)) {
+        if (!['Flash', 'Send', 'Attempt', 'Repeat', 'null'].includes(attemptType)) {
           throw new Error(`Invalid attempt type ${attemptType} for Boulder style`)
         }
         break


### PR DESCRIPTION
Allow "Repeat" for most kinds of ticks (excluding TR, Follow, and Aid).

https://github.com/OpenBeta/open-tacos/issues/1277

Here is the corresponding front-end change: https://github.com/OpenBeta/open-tacos/pull/1289

![Screenshot 2025-02-22 at 2 40 52 PM](https://github.com/user-attachments/assets/441ec74b-e878-4e0e-a15d-31074fb4da26)

