### PR TITLE
bulk areas query

### DIFF
--- a/src/db/AreaTypes.ts
+++ b/src/db/AreaTypes.ts
@@ -257,3 +257,7 @@ export enum OperationType {
   /** Set areas' sorting index */
   orderAreas = 'orderArea'
 }
+
+export interface BulkAreasGQLQueryInput {
+  ancestors: string[]
+}

--- a/src/graphql/area/AreaQueries.ts
+++ b/src/graphql/area/AreaQueries.ts
@@ -1,4 +1,4 @@
-import { AreaType } from '../../db/AreaTypes'
+import { AreaType, BulkAreasGQLQueryInput } from '../../db/AreaTypes'
 import { GQLContext } from '../../types'
 
 const AreaQueries = {
@@ -11,8 +11,13 @@ const AreaQueries = {
   countries: async (_, params, { dataSources }: GQLContext): Promise<AreaType[]> => {
     const { areas } = dataSources
     return await areas.listAllCountries()
-  }
+  },
 
+  bulkAreas: async (_: any, params, { dataSources }: GQLContext): Promise<AreaType[]> => {
+    const { areas } = dataSources
+    const { ancestors } = params as BulkAreasGQLQueryInput
+    return await areas.bulkDownloadAreas(ancestors)
+  }
 }
 
 export default AreaQueries

--- a/src/graphql/schema/Area.gql
+++ b/src/graphql/schema/Area.gql
@@ -1,6 +1,13 @@
 type Query {
   area(uuid: ID): Area
   areas(filter: Filter, sort: Sort): [Area]
+
+  """
+  Bulk download an area and its children starting from ancestors paths (inclusive).
+  To keep payload at a reasonable size ancestors must have at least 2 elements.
+  """
+  bulkAreas(ancestors: [String!]!): [Area]
+
   stats: Stats
   cragsNear(
     placeId: String

--- a/src/model/AreaDataSource.ts
+++ b/src/model/AreaDataSource.ts
@@ -1,3 +1,5 @@
+import { GraphQLError } from 'graphql'
+import { ApolloServerErrorCode } from '@apollo/server/errors'
 import { MongoDataSource } from 'apollo-datasource-mongodb'
 import { Filter } from 'mongodb'
 import muuid from 'uuid-mongodb'
@@ -274,5 +276,17 @@ export default class AreaDataSource extends MongoDataSource<AreaType> {
       'metadata.leaf': zoom >= 11
     }
     return await this.areaModel.find(filter).lean()
+  }
+
+  async bulkDownloadAreas (ancestors: string[]): Promise<AreaType[]> {
+    if (ancestors.length < 2) {
+      throw new GraphQLError('Must provide at least 2 ancestors.', {
+        extensions: {
+          code: ApolloServerErrorCode.BAD_USER_INPUT
+        }
+      })
+    }
+    const ancestorsCSV = ancestors.join(',')
+    return await this.findDescendantsByPath(ancestorsCSV)
   }
 }


### PR DESCRIPTION
Issue #442 

- New query `bulkAreas(ancestors: string[]): AreaType[]` to get all areas with a common ancestor path.   **ancestors** is an array of area uuid's starting from the country root node, which is same as an area `ancestors` field.
- Max payload is [hard coded at 10MB](https://github.com/OpenBeta/openbeta-graphql/blob/247f8a95b72dc78ed4bce39b1270b38c8e116bbc/src/server.ts#L61).  I haven't tested querying some of the largest states (Colorado, CA, Utah) with all the usual fields.

In this example, we're getting Arizona and its descendants, another word any areas with ancestors starting with USA / Arizona.

<img width="1068" alt="Screenshot 2025-02-26 at 6 07 23 PM" src="https://github.com/user-attachments/assets/3212cf30-f167-474a-99ad-c7371aad3a96" />


@Vichy97 would something like this work?
