### PR TITLE
Bulk adding new routes - ordering of routes gets scrambled and requires reordering

### DIFF
--- a/src/model/MutableClimbDataSource.ts
+++ b/src/model/MutableClimbDataSource.ts
@@ -110,16 +110,17 @@ export default class MutableClimbDataSource extends ClimbDataSource {
     // when adding new climbs, ensure they are added in expected sort order, such that:
     // * multiple climbs keep the order they're input in.
     // * all newly added climbs come after existing climbs.
-    let newClimbLeftRightIndex = (await this.climbModel
+    const maxExisting = (await this.climbModel
       .find({ _id: { $in: parent.climbs } })
       .select('metadata.left_right_index')
       .sort({ 'metadata.left_right_index': -1 })
-      .limit(1))[0]
-      ?.metadata.left_right_index ?? 1
+      .limit(1))[0]?.metadata.left_right_index
+    let newClimbLeftRightIndex = (maxExisting ?? 0) + 1
+
     function resolveLeftRightIndex (i: number): { left_right_index: number } | null {
       // user input is always prioritized
       if (userInput[i].leftRightIndex !== undefined) {
-        return { left_right_index: userInput[i].leftRightIndex! }
+        return { left_right_index: userInput[i].leftRightIndex ?? 0 }
       }
       // otherwise, auto-order new climbs
       if (!idList[i].existed) {

--- a/src/model/MutableClimbDataSource.ts
+++ b/src/model/MutableClimbDataSource.ts
@@ -119,7 +119,7 @@ export default class MutableClimbDataSource extends ClimbDataSource {
 
     function resolveLeftRightIndex (i: number): { left_right_index: number } | null {
       // user input is always prioritized
-      if (userInput[i].leftRightIndex !== undefined) {
+      if (userInput[i].leftRightIndex != null) {
         return { left_right_index: userInput[i].leftRightIndex ?? 0 }
       }
       // otherwise, auto-order new climbs

--- a/src/model/MutableClimbDataSource.ts
+++ b/src/model/MutableClimbDataSource.ts
@@ -107,6 +107,16 @@ export default class MutableClimbDataSource extends ClimbDataSource {
 
     const newDocs: ClimbChangeDocType[] = []
 
+    // when adding new climbs, ensure they are added in expected sort order, such that:
+    // * multiple climbs keep the order they're input in.
+    // * all newly added climbs come after existing climbs.
+    let newClimbLeftRightIndex = await this.climbModel
+      .find({ _id: { $in: parent.climbs } })
+      .select('metadata.left_right_index')
+      .sort({ 'metadata.left_right_index': -1 })
+      .limit(1)[0]
+      ?.metadata.left_right_index ?? 1
+
     for (let i = 0; i < userInput.length; i++) {
       // when adding new climbs we require name and disciplines
       if (!idList[i].existed && userInput[i].name == null) {
@@ -186,6 +196,8 @@ export default class MutableClimbDataSource extends ClimbDataSource {
         metadata: {
           areaRef: parent.metadata.area_id,
           lnglat: parent.metadata.lnglat,
+          // waterfall left_right_index -- new climbs get auto incremented, but user input always overrides
+          ...!idList[i].existed && { left_right_index: newClimbLeftRightIndex++ },
           ...userInput[i]?.leftRightIndex != null && { left_right_index: userInput[i].leftRightIndex }
         },
         ...!idList[i].existed && { createdBy: experimentalUserId ?? userId },

--- a/src/model/MutableClimbDataSource.ts
+++ b/src/model/MutableClimbDataSource.ts
@@ -110,12 +110,23 @@ export default class MutableClimbDataSource extends ClimbDataSource {
     // when adding new climbs, ensure they are added in expected sort order, such that:
     // * multiple climbs keep the order they're input in.
     // * all newly added climbs come after existing climbs.
-    let newClimbLeftRightIndex = await this.climbModel
+    let newClimbLeftRightIndex = (await this.climbModel
       .find({ _id: { $in: parent.climbs } })
       .select('metadata.left_right_index')
       .sort({ 'metadata.left_right_index': -1 })
-      .limit(1)[0]
+      .limit(1))[0]
       ?.metadata.left_right_index ?? 1
+    function resolveLeftRightIndex (i: number): { left_right_index: number } | null {
+      // user input is always prioritized
+      if (userInput[i].leftRightIndex !== undefined) {
+        return { left_right_index: userInput[i].leftRightIndex! }
+      }
+      // otherwise, auto-order new climbs
+      if (!idList[i].existed) {
+        return { left_right_index: newClimbLeftRightIndex++ }
+      }
+      return null
+    }
 
     for (let i = 0; i < userInput.length; i++) {
       // when adding new climbs we require name and disciplines
@@ -196,9 +207,7 @@ export default class MutableClimbDataSource extends ClimbDataSource {
         metadata: {
           areaRef: parent.metadata.area_id,
           lnglat: parent.metadata.lnglat,
-          // waterfall left_right_index -- new climbs get auto incremented, but user input always overrides
-          ...!idList[i].existed && { left_right_index: newClimbLeftRightIndex++ },
-          ...userInput[i]?.leftRightIndex != null && { left_right_index: userInput[i].leftRightIndex }
+          ...resolveLeftRightIndex(i)
         },
         ...!idList[i].existed && { createdBy: experimentalUserId ?? userId },
         ...idList[i].existed && { updatedBy: userId },

--- a/src/model/__tests__/MutableClimbDataSource.ts
+++ b/src/model/__tests__/MutableClimbDataSource.ts
@@ -212,7 +212,13 @@ describe('Climb CRUD', () => {
     ).rejects.toThrowError(/You can only add climbs to a crag/)
 
     // Route-only area should accept new boulder problems
-    await climbs.addOrUpdateClimbs(testUser, routesArea.metadata.area_id, [newBoulderProblem1])
+    const [newBoulderID] = await climbs.addOrUpdateClimbs(testUser, routesArea.metadata.area_id, [newBoulderProblem1])
+    // Should come after existing climbs
+    expect(await climbs.findOneClimbByMUUID(muid.from(newBoulderID))).toMatchObject({
+      metadata: {
+        left_right_index: newClimbsToAdd.length + 1
+      }
+    })
   })
 
   it('can add new boulder problems', async () => {

--- a/src/model/__tests__/MutableClimbDataSource.ts
+++ b/src/model/__tests__/MutableClimbDataSource.ts
@@ -178,22 +178,33 @@ describe('Climb CRUD', () => {
     const newIDs = await climbs.addOrUpdateClimbs(
       testUser,
       routesArea.metadata.area_id,
-      newClimbsToAdd)
+      newClimbsToAdd
+    )
 
     expect(newIDs).toHaveLength(newClimbsToAdd.length)
 
-    const climb0 = await climbs.findOneClimbByMUUID(muid.from(newIDs[0]))
+    // Validate all climbs were added, and in the order we expect
+    for (const [i, climbIn] of newClimbsToAdd.entries()) {
+      const climbOut = await climbs.findOneClimbByMUUID(muid.from(newIDs[i]))
 
-    // Validate new climb
-    expect(climb0).toMatchObject({
-      name: newClimbsToAdd[0].name,
-      type: sanitizeDisciplines(newClimbsToAdd[0].disciplines),
-      content: {
-        description: newClimbsToAdd[0].description,
-        location: newClimbsToAdd[0].location,
-        protection: newClimbsToAdd[0].protection
-      }
-    })
+      // Validate new climb
+      expect(climbOut).toMatchObject({
+        name: climbIn.name,
+        type: sanitizeDisciplines(climbIn.disciplines),
+        metadata: {
+          left_right_index: i + 1
+        },
+        ...climbIn.description === undefined
+          ? {}
+          : {
+              content: {
+                description: climbIn.description,
+                location: climbIn.location,
+                protection: climbIn.protection
+              }
+            }
+      })
+    }
 
     // California contains subareas.  Should fail.
     await expect(


### PR DESCRIPTION
- [x] We have a test coverage for adding climbs, but also add test for how new climb gets ordered with existing climbs

---
name: Pull request
about: Create a pull request
title: Bulk adding new routes - ordering of routes gets scrambled and requires reordering
labels: bug, feature ?
assignees: Greg Hart

---

## What type of PR is this?(check all applicable)
- [ ] refactor
- [x] feature
- [x] bug fix
- [ ] documentation
- [ ] optimization
- [ ] other

## Description

Per related issue, when adding multiple climbs, we don't persist the ordering 

### Related Issues

Issue [#1255](https://github.com/OpenBeta/open-tacos/issues/1255)

### What this PR achieves

This PR changes `addOrUpdateClimbs` to persist the order of incoming arrays of climbs using `left_right_index` (when not already given0.
It also formalizes whether new climbs should come after or before existing climbs (when `left_right_index` is not given) -- currently it changes this so new climbs come after instead of before.

### Screenshots, recordings

![image](https://github.com/user-attachments/assets/21ebc2ef-3a55-4d86-9b0a-a9614508251c)

### Notes


