### PR TITLE
Migration to fix invalid ticks

### DIFF
--- a/db-migrations/0006-capitalize-tick-style-and-attempt-type.js
+++ b/db-migrations/0006-capitalize-tick-style-and-attempt-type.js
@@ -1,0 +1,59 @@
+// This migration will update all tick styles and attemptTypes with incorrect capitalization
+const tickCapitalizationRs = db.ticks.updateMany(
+  {
+    $or: [
+      { style: 'lead' },
+      { style: 'follow' },
+      { style: 'tr' },
+      { style: 'top_rope' },
+      { style: 'solo' },
+      { style: 'aid' },
+      { style: 'boulder' },
+      { attemptType: 'onsight' },
+      { attemptType: 'redpoint' },
+      { attemptType: 'flash' },
+      { attemptType: 'pinkpoint' },
+      { attemptType: 'send' },
+      { attemptType: 'attempt' },
+      { attemptType: 'frenchfree' },
+      { attemptType: 'repeat' }
+    ]
+  },
+  [
+    {
+      $set: {
+        style: {
+          $switch: {
+            branches: [
+              { case: { $eq: ['$style', 'lead'] }, then: 'Lead' },
+              { case: { $eq: ['$style', 'follow'] }, then: 'Follow' },
+              { case: { $eq: ['$style', 'tr'] }, then: 'TR' },
+              { case: { $eq: ['$style', 'top_rope'] }, then: 'TR' },
+              { case: { $eq: ['$style', 'solo'] }, then: 'Solo' },
+              { case: { $eq: ['$style', 'aid'] }, then: 'Aid' },
+              { case: { $eq: ['$style', 'boulder'] }, then: 'Boulder' }
+            ],
+            default: '$style'
+          }
+        },
+        attemptType: {
+          $switch: {
+            branches: [
+              { case: { $eq: ['$attemptType', 'redpoint'] }, then: 'Redpoint' },
+              { case: { $eq: ['$attemptType', 'onsight'] }, then: 'Onsight' },
+              { case: { $eq: ['$attemptType', 'flash'] }, then: 'Flash' },
+              { case: { $eq: ['$attemptType', 'pinkpoint'] }, then: 'Pinkpoint' },
+              { case: { $eq: ['$attemptType', 'send'] }, then: 'Send' },
+              { case: { $eq: ['$attemptType', 'attempt'] }, then: 'Attempt' },
+              { case: { $eq: ['$attemptType', 'frenchfree'] }, then: 'Frenchfree' },
+              { case: { $eq: ['$attemptType', 'repeat'] }, then: 'Repeat' }
+            ],
+            default: '$attemptType'
+          }
+        }
+      },
+    }
+  ]
+);
+
+printjson(tickCapitalizationRs);

--- a/db-migrations/0007-tick-style-nullification.js
+++ b/db-migrations/0007-tick-style-nullification.js
@@ -1,0 +1,21 @@
+// This migration will update all ticks that have values of "N/A" for style or attemptType by unsetting those fields
+const tickStyleNullificationRs = db.ticks.updateMany(
+  {
+    style: "N/A"
+  },
+  {
+    $unset: { style: "" }
+  }
+);
+
+const tickAttemptTypeNullificationRs = db.ticks.updateMany(
+  {
+    attemptType: "N/A"
+  },
+  {
+    $unset: { attemptType: "" }
+  }
+);
+
+printjson(tickStyleNullificationRs);
+printjson(tickAttemptTypeNullificationRs);

--- a/db-migrations/0008-fix-swapped-tick-style.js
+++ b/db-migrations/0008-fix-swapped-tick-style.js
@@ -1,0 +1,52 @@
+// This migration will fix ticks where attemptType has a value that belongs in style instead.
+const attemptTypeToStyleRs = db.ticks.updateMany(
+  {
+    $or: [
+      { attemptType: 'Lead' },
+      { attemptType: 'TR' },
+      { attemptyType: 'Follow' },
+      { attemptyType: 'Solo' },
+      { attemptyType: 'Aid' },
+      { attemptyType: 'Boulder' }
+    ]
+  },
+  [
+    {
+      $set: {
+        style: {
+          $switch: {
+            branches: [
+              { case: { $eq: ['$attemptType', 'Lead'] }, then: 'Lead' },
+              { case: { $eq: ['$attemptType', 'TR'] }, then: 'TR' },
+              { case: { $eq: ['$attemptType', 'Follow'] }, then: 'Follow' },
+              { case: { $eq: ['$attemptType', 'Solo'] }, then: 'Solo' },
+              { case: { $eq: ['$attemptType', 'Aid'] }, then: 'Aid' },
+              { case: { $eq: ['$attemptType', 'Boulder'] }, then: 'Boulder' }
+            ],
+            default: '$style'
+          }
+        }
+      }
+    }
+  ]
+);
+
+// Now nullify the attemptType field since we've moved that value to style
+const nullifyAttemptTypeRs = db.ticks.updateMany(
+  {
+    $or: [
+      { attemptType: 'Lead' },
+      { attemptType: 'TR' },
+      { attemptyType: 'Follow' },
+      { attemptyType: 'Solo' },
+      { attemptyType: 'Aid' },
+      { attemptyType: 'Boulder' }
+    ]
+  },
+  {
+    $unset: { attemptType: "" }
+  }
+);
+
+printjson(attemptTypeToStyleRs);
+printjson(nullifyAttemptTypeRs);

--- a/db-migrations/0009-fix-some-bouldering-ticks.js
+++ b/db-migrations/0009-fix-some-bouldering-ticks.js
@@ -1,0 +1,47 @@
+// This migration will fix ticks where the style was set to a value that belongs in attemptType instead, specifically for boulders
+// this is likely specific to one user, but it can be run for all ticks that may be affected.
+
+// Move the value of style to attemptType (and capitalize it)
+const incorrectBoulderTick1Rs = db.ticks.updateMany(
+  {
+    $or: [
+      { style: 'send' },
+      { style: 'attempt' },
+      { style: 'flash' }
+    ]
+  },
+  [
+    {
+      $set: {
+        attemptType: {
+          $switch: {
+            branches: [
+              { case: { $eq: ['$style', 'send'] }, then: 'Send' },
+              { case: { $eq: ['$style', 'attempt'] }, then: 'Attempt' },
+              { case: { $eq: ['$style', 'flash'] }, then: 'Flash' }
+            ]
+          }
+        }
+      }
+    }
+  ]
+);
+
+// Set style to 'Boulder'
+const incorrectBoulderTick2Rs = db.ticks.updateMany(
+  {
+    $or: [
+      { style: 'send' },
+      { style: 'attempt' },
+      { style: 'flash' }
+    ]
+  },
+  [
+    {
+      $set: { style: 'Boulder' }
+    }
+  ]
+);
+
+printjson(incorrectBoulderTick1Rs);
+printjson(incorrectBoulderTick2Rs);


### PR DESCRIPTION
after adding tick validation recently, many ticks in the database are now "invalid", causing some users to not be able to see any of their ticks. these migrations should handle most or all cases on invalid ticks that are likely to exist.