### PR TITLE
feat: return all leaf+non-leaf areas

### DIFF
--- a/src/model/AreaDataSource.ts
+++ b/src/model/AreaDataSource.ts
@@ -287,6 +287,10 @@ export default class AreaDataSource extends MongoDataSource<AreaType> {
       })
     }
     const ancestorsCSV = ancestors.join(',')
-    return await this.findDescendantsByPath(ancestorsCSV)
+    const [leafAreas, nonLeafAreas] = await Promise.all([
+      this.findDescendantsByPath(ancestorsCSV, true),
+      this.findDescendantsByPath(ancestorsCSV, false)
+    ])
+    return nonLeafAreas.concat(leafAreas)
   }
 }


### PR DESCRIPTION
Resolves [this issue](https://github.com/OpenBeta/openbeta-graphql/issues/457)

BulkAreas query now return both leaf and non-leaf areas, instead of only non-leaf areas. It also fetches leaf and non-leaf areas in paralles, so this hopefully won't be much or any of a performance hit on the bulkAreas query.