### PR TITLE
Revert "Assert json types is long since deprecated"

### DIFF
--- a/src/__tests__/bulkImport.test.ts
+++ b/src/__tests__/bulkImport.test.ts
@@ -4,7 +4,7 @@ import express from "express";
 import {InMemoryDB} from "../utils/inMemoryDB.js";
 import {queryAPI, setUpServer} from "../utils/testUtils.js";
 import {muuidToString} from "../utils/helpers.js";
-import exampleImportData from './import-example.json'
+import exampleImportData from './import-example.json' assert {type: 'json'};
 import {AreaType} from "../db/AreaTypes.js";
 import {BulkImportResultType} from "../db/BulkImportTypes.js";
 import MutableClimbDataSource from "../model/MutableClimbDataSource.js";

--- a/src/db/import/usa/AreaTransformer.ts
+++ b/src/db/import/usa/AreaTransformer.ts
@@ -1,7 +1,7 @@
 import mongoose from 'mongoose'
 import { geometry, Point } from '@turf/helpers'
 import isoCountries from 'i18n-iso-countries'
-import enJson from 'i18n-iso-countries/langs/en.json'
+import enJson from 'i18n-iso-countries/langs/en.json' assert { type: 'json' }
 
 import { getAreaModel } from '../../AreaSchema.js'
 import { AreaType } from '../../AreaTypes'

--- a/src/db/utils/jobs/AddCountriesJob.ts
+++ b/src/db/utils/jobs/AddCountriesJob.ts
@@ -1,4 +1,4 @@
-import enJson from 'i18n-iso-countries/langs/en.json'
+import enJson from 'i18n-iso-countries/langs/en.json' assert { type: 'json' }
 
 import { connectDB, gracefulExit } from '../../index.js'
 import MutableAreaDataSource from '../../../model/MutableAreaDataSource.js'

--- a/src/model/MutableAreaDataSource.ts
+++ b/src/model/MutableAreaDataSource.ts
@@ -3,14 +3,14 @@ import { geometry, Point } from '@turf/helpers'
 import { GraphQLError } from 'graphql'
 import { ApolloServerErrorCode } from '@apollo/server/errors'
 import isoCountries from 'i18n-iso-countries'
-import enJson from 'i18n-iso-countries/langs/en.json'
+import enJson from 'i18n-iso-countries/langs/en.json' assert {type: 'json'}
 import { produce } from 'immer'
 import mongoose, { ClientSession } from 'mongoose'
 import { NIL, v5 as uuidv5 } from 'uuid'
 import muuid, { MUUID } from 'uuid-mongodb'
 
 import { GradeContexts } from '../GradeUtils.js'
-import CountriesLngLat from '../data/countries-with-lnglat.json'
+import CountriesLngLat from '../data/countries-with-lnglat.json' assert {type: 'json'}
 import {
   AreaDocumnent,
   AreaEditableFieldsType,


### PR DESCRIPTION
Reverts OpenBeta/openbeta-graphql#467

Problem:

Jest complains about this EVERY time the test runs, but as far as I can tell this is **ACTUALLY** needed for us to run. Not only that, but tests will not catch this.

The build process also doesn't catch this - I'm still suspicious that something is not properly configured but reversion is the best immediate course