### PR TITLE
Refactor mutable area datasource to prevent param explosion

### DIFF
--- a/src/__tests__/areas.ts
+++ b/src/__tests__/areas.ts
@@ -41,8 +41,8 @@ describe('areas API', () => {
     areas = MutableAreaDataSource.getInstance()
     organizations = MutableOrganizationDataSource.getInstance()
     usa = await areas.addCountry('usa')
-    ca = await areas.addArea(user, 'CA', usa.metadata.area_id)
-    wa = await areas.addArea(user, 'WA', usa.metadata.area_id)
+    ca = await areas.addArea(user, { areaName: 'CA', parentUuid: usa.metadata.area_id })
+    wa = await areas.addArea(user, { areaName: 'WA', parentUuid: usa.metadata.area_id })
   })
 
   afterAll(async () => {

--- a/src/__tests__/bulkImport.test.ts
+++ b/src/__tests__/bulkImport.test.ts
@@ -56,7 +56,7 @@ describe('bulkImportAreas', () => {
   beforeEach(async () => {
     await inMemoryDB.clear()
     await bulkImport.addCountry('usa')
-    testArea = await bulkImport.addArea(user, "Test Area", null, "us")
+    testArea = await bulkImport.addArea(user, { areaName: "Test Area", countryCode: "us" })
   })
 
   afterAll(async () => {

--- a/src/__tests__/history.ts
+++ b/src/__tests__/history.ts
@@ -97,7 +97,7 @@ describe('history API', () => {
     it('queries recent change history successfully', async () => {
       // Make changes to be tracked.
       usa = await areas.addCountry('usa')
-      ca = await areas.addArea(user, 'CA', usa.metadata.area_id)
+      ca = await areas.addArea(user, { areaName: 'CA', parentUuid: usa.metadata.area_id })
       const alphaFields = {
         displayName: 'Alpha OpenBeta Club',
         associatedAreaIds: [usa.metadata.area_id],

--- a/src/__tests__/organizations.ts
+++ b/src/__tests__/organizations.ts
@@ -38,8 +38,8 @@ describe('organizations API', () => {
     areas = MutableAreaDataSource.getInstance()
     organizations = MutableOrganizationDataSource.getInstance()
     usa = await areas.addCountry('usa')
-    ca = await areas.addArea(user, 'CA', usa.metadata.area_id)
-    wa = await areas.addArea(user, 'WA', usa.metadata.area_id)
+    ca = await areas.addArea(user, { areaName: 'CA', parentUuid: usa.metadata.area_id })
+    wa = await areas.addArea(user, { areaName: 'WA', parentUuid: usa.metadata.area_id })
   })
 
   afterAll(async () => {

--- a/src/__tests__/ticks.ts
+++ b/src/__tests__/ticks.ts
@@ -74,8 +74,8 @@ describe('ticks API', () => {
 
     // Add climbs because add/update tick requires type validation
     await areas.addCountry('usa')
-    const newDestination = await areas.addArea(user, 'California', null, 'usa')
-    const routesArea = await areas.addArea(user, 'Sport & Trad', newDestination.metadata.area_id)
+    const newDestination = await areas.addArea(user, { areaName: 'California', countryCode: 'usa' })
+    const routesArea = await areas.addArea(user, { areaName: 'Sport & Trad', parentUuid: newDestination.metadata.area_id })
 
     const newIDs = await climbs.addOrUpdateClimbs(user, routesArea.metadata.area_id, newClimbsToAdd)
     // Update tick inputs with generated climb IDs

--- a/src/graphql/area/AreaMutations.ts
+++ b/src/graphql/area/AreaMutations.ts
@@ -36,12 +36,15 @@ const AreaMutations = {
     if (user?.uuid == null) throw new Error('Missing user uuid')
 
     return await areas.addArea(
-      user.uuid, name,
-      parentUuid == null ? null : muuid.from(parentUuid),
-      countryCode,
-      experimentalAuthor,
-      isLeaf,
-      isBoulder
+      user.uuid,
+      {
+        areaName: name,
+        countryCode,
+        experimentalAuthor,
+        isLeaf,
+        isBoulder,
+        parentUuid: parentUuid == null ? undefined : muuid.from(parentUuid)
+      }
     )
   },
 

--- a/src/graphql/schema/AreaEdit.gql
+++ b/src/graphql/schema/AreaEdit.gql
@@ -49,6 +49,8 @@ input AreaInput {
   isLeaf: Boolean
   isBoulder: Boolean
   experimentalAuthor: ExperimentalAuthorType
+  lat: Float
+  lng: Float
 }
 
 """

--- a/src/model/BulkImportDataSource.ts
+++ b/src/model/BulkImportDataSource.ts
@@ -93,13 +93,14 @@ export default class BulkImportDataSource extends MutableAreaDataSource {
           throw new Error(`area with id ${areaNode.uuid.toUUID().toString()} (${areaNode.areaName ?? 'unknown name'}) not found`)
         }
       } else if (areaNode.areaName != null) {
-        area = await this.addAreaWith({
-          user,
-          areaName: areaNode.areaName,
-          countryCode: areaNode.countryCode,
-          parentUuid,
+        area = await this.addAreaWith(user,
+          {
+            areaName: areaNode.areaName,
+            countryCode: areaNode.countryCode,
+            parentUuid
+          },
           session
-        }).then(async (area) => {
+        ).then(async (area) => {
           return await this.updateArea(user, area.metadata.area_id, {
             description: areaNode.description,
             leftRightIndex: areaNode.leftRightIndex,

--- a/src/model/MutableAreaDataSource.ts
+++ b/src/model/MutableAreaDataSource.ts
@@ -34,15 +34,15 @@ import { getAreaModel } from '../db/AreaSchema.js'
 
 isoCountries.registerLocale(enJson)
 
-export interface AddAreaOptions {
-  user: MUUID
+interface AddAreaOptions {
   areaName: string
-  parentUuid?: MUUID | null
+  parentUuid?: MUUID
   countryCode?: string
   experimentalAuthor?: ExperimentalAuthorType
   isLeaf?: boolean
   isBoulder?: boolean
-  session?: ClientSession
+  lat?: number
+  lng?: number
 }
 
 export interface UpdateAreaOptions {
@@ -158,17 +158,10 @@ export default class MutableAreaDataSource extends AreaDataSource {
     throw new Error('Error inserting ' + countryCode)
   }
 
-  async addAreaWith ({
-    user,
-    areaName,
-    parentUuid = null,
-    countryCode,
-    experimentalAuthor,
-    isLeaf,
-    isBoulder,
-    session
-  }: AddAreaOptions): Promise<AreaType> {
-    return await this.addArea(user, areaName, parentUuid, countryCode, experimentalAuthor, isLeaf, isBoulder, session)
+  async addAreaWith (user: MUUID, props: AddAreaOptions, session?: ClientSession): Promise<AreaType> {
+    return await this.addArea(
+      user, props, session
+    )
   }
 
   /**
@@ -178,14 +171,13 @@ export default class MutableAreaDataSource extends AreaDataSource {
    * @param parentUuid
    * @param countryCode
    */
-  async addArea (user: MUUID,
-    areaName: string,
-    parentUuid: MUUID | null,
-    countryCode?: string,
-    experimentalAuthor?: ExperimentalAuthorType,
-    isLeaf?: boolean,
-    isBoulder?: boolean,
-    sessionCtx?: ClientSession): Promise<AreaType> {
+  async addArea (
+    user: MUUID,
+    props: AddAreaOptions,
+    sessionCtx?: ClientSession
+  ): Promise<AreaType> {
+    const { parentUuid, countryCode, areaName } = props
+
     if (parentUuid == null && countryCode == null) {
       throw new Error(`Adding area "${areaName}" failed. Must provide parent Id or country code`)
     }
@@ -199,12 +191,15 @@ export default class MutableAreaDataSource extends AreaDataSource {
       throw new Error(`Adding area "${areaName}" failed. Unable to determine parent id or country code`)
     }
 
+    // We can update the prop in place and pass it on to the rest of the logic
+    props.parentUuid = parentId
+
     const session = sessionCtx ?? await this.areaModel.startSession()
     try {
       if (session.inTransaction()) {
-        return await this._addArea(session, user, areaName, parentId, experimentalAuthor, isLeaf, isBoulder)
+        return await this._addArea(session, user, props)
       } else {
-        return await withTransaction(session, async () => await this._addArea(session, user, areaName, parentId, experimentalAuthor, isLeaf, isBoulder))
+        return await withTransaction(session, async () => await this._addArea(session, user, props))
       }
     } finally {
       if (sessionCtx == null) {
@@ -213,13 +208,18 @@ export default class MutableAreaDataSource extends AreaDataSource {
     }
   }
 
-  async _addArea (session, user: MUUID, areaName: string, parentUuid: MUUID, experimentalAuthor?: ExperimentalAuthorType, isLeaf?: boolean, isBoulder?: boolean): Promise<any> {
+  async _addArea (session, user: MUUID, props: AddAreaOptions): Promise<any> {
+    const { areaName, parentUuid, isLeaf, isBoulder, experimentalAuthor } = props
     const parentFilter = { 'metadata.area_id': parentUuid }
-    const parent = await this.areaModel.findOne(parentFilter).session(session).orFail(new GraphQLError(`[${areaName}]: Expecting country or area parent, found none with id ${parentUuid.toString()}`, {
-      extensions: {
-        code: ApolloServerErrorCode.BAD_USER_INPUT
-      }
-    }))
+    const parent = await this
+      .areaModel
+      .findOne(parentFilter)
+      .session(session)
+      .orFail(new GraphQLError(`[${areaName}]: Expecting country or area parent, found none with id ${(parentUuid ?? 0).toString()}`, {
+        extensions: {
+          code: ApolloServerErrorCode.BAD_USER_INPUT
+        }
+      }))
 
     if (parent.metadata.leaf || (parent.metadata?.isBoulder ?? false)) {
       if (parent.children.length > 0 || parent.climbs.length > 0) {

--- a/src/model/__tests__/AreaHistoryDataSource.ts
+++ b/src/model/__tests__/AreaHistoryDataSource.ts
@@ -38,8 +38,8 @@ describe('Area history', () => {
     const newArea = await areas.findOneAreaByUUID(usa.metadata.area_id)
     expect(newArea.area_name).toEqual(usa.area_name)
 
-    const or = await areas.addArea(testUser, 'oregon', usa.metadata.area_id)
-    const nv = await areas.addArea(testUser, 'nevada', usa.metadata.area_id)
+    const or = await areas.addArea(testUser, { areaName: 'oregon', parentUuid: usa.metadata.area_id })
+    const nv = await areas.addArea(testUser, { areaName: 'nevada', parentUuid: usa.metadata.area_id })
 
     expect(nv?._id).toBeTruthy()
     expect(or?._id).toBeTruthy()
@@ -94,7 +94,7 @@ describe('Area history', () => {
 
   it('should record multiple Areas.setDestination() calls ', async () => {
     const canada = await areas.addCountry('can')
-    const squamish = await areas.addArea(testUser, 'squamish', canada.metadata.area_id)
+    const squamish = await areas.addArea(testUser, { areaName: 'squamish', parentUuid: canada.metadata.area_id })
 
     expect(squamish?._id).toBeTruthy()
 
@@ -121,7 +121,7 @@ describe('Area history', () => {
 
   it('should record an Areas.deleteArea() call', async () => {
     const greece = await areas.addCountry('grc')
-    const leonidio = await areas.addArea(testUser, 'Leonidio', greece.metadata.area_id)
+    const leonidio = await areas.addArea(testUser, { areaName: 'Leonidio', parentUuid: greece.metadata.area_id })
 
     if (leonidio == null) fail()
 
@@ -139,11 +139,11 @@ describe('Area history', () => {
 
   it('should not record a failed Areas.deleteArea() call', async () => {
     const spain = await areas.addCountry('esp')
-    const margalef = await areas.addArea(testUser, 'margalef', spain.metadata.area_id)
+    const margalef = await areas.addArea(testUser, { areaName: 'margalef', parentUuid: spain.metadata.area_id })
 
     if (margalef == null) fail()
 
-    const newChild = await areas.addArea(testUser, 'One', margalef.metadata.area_id)
+    const newChild = await areas.addArea(testUser, { areaName: 'One', parentUuid: margalef.metadata.area_id })
 
     if (newChild == null) fail()
 

--- a/src/model/__tests__/MediaDataSource.ts
+++ b/src/model/__tests__/MediaDataSource.ts
@@ -63,9 +63,9 @@ describe('MediaDataSource', () => {
     await createIndexes()
 
     await areas.addCountry('USA')
-    areaForTagging1 = await areas.addArea(muuid.v4(), 'Yosemite NP', null, 'USA')
-    areaForTagging2 = await areas.addArea(muuid.v4(), 'Lake Tahoe', null, 'USA')
-    areaForTagging3 = await areas.addArea(muuid.v4(), 'Shelf Road', null, 'USA')
+    areaForTagging1 = await areas.addArea(muuid.v4(), { areaName: 'Yosemite NP', countryCode: 'USA' })
+    areaForTagging2 = await areas.addArea(muuid.v4(), { areaName: 'Lake Tahoe', countryCode: 'USA' })
+    areaForTagging3 = await areas.addArea(muuid.v4(), { areaName: 'Shelf Road', countryCode: 'USA' })
     if (areaForTagging1 == null || areaForTagging2 == null || areaForTagging3 == null) fail('Fail to pre-seed test areas')
 
     const rs = await climbs.addOrUpdateClimbs(muuid.v4(), areaForTagging1.metadata.area_id, [newSportClimb1])

--- a/src/model/__tests__/MutableAreaDataSource.test.ts
+++ b/src/model/__tests__/MutableAreaDataSource.test.ts
@@ -34,12 +34,12 @@ describe("Test area mutations", () => {
 
         return areas.addArea(
             testUser,
-            name,
-            parent ?? rootCountry.metadata.area_id,
-            undefined,
-            undefined,
-            extra?.leaf,
-            extra?.boulder
+            {
+            areaName: name,
+            parentUuid: parent ?? rootCountry.metadata.area_id,
+            isLeaf: extra?.leaf,
+            isBoulder: extra?.boulder,
+        }
         )
     }
 
@@ -57,7 +57,7 @@ describe("Test area mutations", () => {
 
       describe("Add area param cases", () => {
         test("Add a simple area with no specifications using a parent UUID", () => areas
-            .addArea(testUser, 'Texas2', rootCountry.metadata.area_id)
+            .addArea(testUser, { areaName: 'Texas2', parentUuid: rootCountry.metadata.area_id })
             .then(area => {
                 expect(area?._change).toMatchObject({
                     user: testUser,
@@ -66,10 +66,12 @@ describe("Test area mutations", () => {
             }))
 
         test("Add an area with an unknown UUID parent should fail",
-                async () => await expect(() => areas.addArea(testUser, 'Texas', muid.v4())).rejects.toThrow())
+                async () => await expect(() => areas.addArea(testUser, { areaName: 'Texas', parentUuid: muid.v4() })).rejects.toThrow())
 
-        test("Add a simple area with no specifications using a country code", () => areas.addArea(testUser, 'Texas part 2', null, 'USA')
-            .then(texas => areas.addArea(testUser, 'Texas Child', texas.metadata.area_id)))
+        test("Add a simple area with no specifications using a country code", () =>
+            areas.addArea(testUser, { areaName: 'Texas part 2', countryCode: 'USA' })
+                .then(texas => areas.addArea(testUser, { areaName: 'Texas Child', parentUuid: texas.metadata.area_id }))
+        )
 
         test("Add a simple area, then specify a new child one level deep", () => addArea('California')
             .then(async parent => {

--- a/src/model/__tests__/MutableClimbDataSource.ts
+++ b/src/model/__tests__/MutableClimbDataSource.ts
@@ -171,10 +171,10 @@ describe('Climb CRUD', () => {
   it('can add new climbs', async () => {
     await areas.addCountry('usa')
 
-    const newDestination = await areas.addArea(testUser, 'California', null, 'usa')
+    const newDestination = await areas.addArea(testUser, { areaName: 'California', countryCode: 'usa' })
     if (newDestination == null) fail('Expect new area to be created')
 
-    const routesArea = await areas.addArea(testUser, 'Sport & Trad', newDestination.metadata.area_id)
+    const routesArea = await areas.addArea(testUser, { areaName: 'Sport & Trad', parentUuid: newDestination.metadata.area_id })
 
     const newIDs = await climbs.addOrUpdateClimbs(
       testUser,
@@ -231,10 +231,10 @@ describe('Climb CRUD', () => {
   it('can add new boulder problems', async () => {
     await areas.addCountry('esp')
 
-    const newDestination = await areas.addArea(testUser, 'Valencia', null, 'esp')
+    const newDestination = await areas.addArea(testUser, { areaName: 'Valencia', countryCode: 'esp' })
     if (newDestination == null) fail('Expect new area to be created')
 
-    const boulderingArea = await areas.addArea(testUser, 'Bouldering only', newDestination.metadata.area_id)
+    const boulderingArea = await areas.addArea(testUser, { areaName: 'Bouldering only', parentUuid: newDestination.metadata.area_id })
 
     expect(boulderingArea.metadata.isBoulder).toBeFalsy()
 
@@ -252,7 +252,7 @@ describe('Climb CRUD', () => {
   })
 
   it('can delete new boulder problems', async () => {
-    const newBoulderingArea = await areas.addArea(testUser, 'Bouldering area 1', null, 'fr')
+    const newBoulderingArea = await areas.addArea(testUser, { areaName: 'Bouldering area 1', countryCode: 'fr' })
     if (newBoulderingArea == null) fail('Expect new area to be created')
 
     const newIDs = await climbs.addOrUpdateClimbs(
@@ -304,7 +304,7 @@ describe('Climb CRUD', () => {
 
   it('handles mixed grades and disciplines correctly', async () => {
     await areas.addCountry('can')
-    const newBoulderingArea = await areas.addArea(testUser, 'Bouldering area 1', null, 'can')
+    const newBoulderingArea = await areas.addArea(testUser, { areaName: 'Bouldering area 1', countryCode: 'can' })
     if (newBoulderingArea == null) fail('Expect new area to be created')
 
     const newIDs = await climbs.addOrUpdateClimbs(
@@ -327,7 +327,7 @@ describe('Climb CRUD', () => {
 
     {
       // A roped climbing area
-      const newClimbingArea = await areas.addArea(testUser, 'Climbing area 1', null, 'aus')
+      const newClimbingArea = await areas.addArea(testUser, { areaName: 'Climbing area 1', countryCode: 'aus' })
       if (newClimbingArea == null) fail('Expect new area to be created')
 
       const newclimbs = [
@@ -374,7 +374,7 @@ describe('Climb CRUD', () => {
 
     {
       // A bouldering area
-      const newBoulderingArea = await areas.addArea(testUser, 'Bouldering area 1', null, 'aus')
+      const newBoulderingArea = await areas.addArea(testUser, { areaName: 'Bouldering area 1', countryCode: 'aus' })
       if (newBoulderingArea == null) fail('Expect new area to be created')
 
       const newIDs = await climbs.addOrUpdateClimbs(
@@ -402,7 +402,7 @@ describe('Climb CRUD', () => {
 
     {
       // A roped climbing area
-      const newClimbingArea = await areas.addArea(testUser, 'Climbing area in Brazil', null, 'bra')
+      const newClimbingArea = await areas.addArea(testUser, { areaName: 'Climbing area in Brazil', countryCode: 'bra' })
       if (newClimbingArea == null) fail('Expect new area to be created in Brazil')
 
       const newclimbs = [
@@ -449,7 +449,7 @@ describe('Climb CRUD', () => {
 
     {
       // A bouldering area
-      const newBoulderingArea = await areas.addArea(testUser, 'Bouldering area 1', null, 'bra')
+      const newBoulderingArea = await areas.addArea(testUser, { areaName: 'Bouldering Area 1', countryCode: 'bra' })
       if (newBoulderingArea == null) fail('Expect new area to be created')
 
       const newIDs = await climbs.addOrUpdateClimbs(
@@ -476,7 +476,7 @@ describe('Climb CRUD', () => {
     await areas.addCountry('deu') // Assuming Germany since UIAA is dominant grading system
 
     // A roped climbing area
-    const newClimbingArea = await areas.addArea(testUser, 'Climbing area 1', null, 'deu')
+    const newClimbingArea = await areas.addArea(testUser, { areaName: 'Climbing area 1', countryCode: 'deu' })
     if (newClimbingArea == null) fail('Expect new area to be created')
 
     const newIDs = await climbs.addOrUpdateClimbs(
@@ -503,7 +503,7 @@ describe('Climb CRUD', () => {
   })
 
   it('can update boulder problems', async () => {
-    const newDestination = await areas.addArea(testUser, 'Bouldering area A100', null, 'fr')
+    const newDestination = await areas.addArea(testUser, { areaName: 'Bouldering area A100', countryCode: 'fr' })
 
     if (newDestination == null) fail('Expect new area to be created')
 
@@ -562,7 +562,7 @@ describe('Climb CRUD', () => {
   })
 
   it('can update climb length, boltsCount & fa', async () => {
-    const newDestination = await areas.addArea(testUser, 'Sport area Z100', null, 'fr')
+    const newDestination = await areas.addArea(testUser, { areaName: 'Sport area Z100', countryCode: 'fr' })
 
     if (newDestination == null) fail('Expect new area to be created')
 
@@ -599,10 +599,10 @@ describe('Climb CRUD', () => {
   it('can add multi-pitch climbs', async () => {
     await areas.addCountry('aut')
 
-    const newDestination = await areas.addArea(testUser, 'Some Location with Multi-Pitch Climbs', null, 'aut')
+    const newDestination = await areas.addArea(testUser, { areaName: 'Some Location with Multi-Pitch Climbs', countryCode: 'aut' })
     if (newDestination == null) fail('Expect new area to be created')
 
-    const routesArea = await areas.addArea(testUser, 'Sport & Trad Multi-Pitches', newDestination.metadata.area_id)
+    const routesArea = await areas.addArea(testUser, { areaName: 'Sport & Trad Multi-Pitches', parentUuid: newDestination.metadata.area_id })
 
     // create new climb with individual pitches
     const newIDs = await climbs.addOrUpdateClimbs(
@@ -639,7 +639,7 @@ describe('Climb CRUD', () => {
   })
 
   it('can update multi-pitch problems', async () => {
-    const newDestination = await areas.addArea(testUser, 'Some Multi-Pitch Area to be Updated', null, 'deu')
+    const newDestination = await areas.addArea(testUser, { areaName: 'Some Multi-Pitch Area to be Updated', countryCode: 'deu' })
 
     if (newDestination == null) fail('Expect new area to be created')
 

--- a/src/model/__tests__/MutableOrganizationDataSource.ts
+++ b/src/model/__tests__/MutableOrganizationDataSource.ts
@@ -28,8 +28,8 @@ describe('Organization', () => {
     organizations = MutableOrganizationDataSource.getInstance()
     areas = MutableAreaDataSource.getInstance()
     usa = await areas.addCountry('usa')
-    ca = await areas.addArea(testUser, 'CA', usa.metadata.area_id)
-    wa = await areas.addArea(testUser, 'WA', usa.metadata.area_id)
+    ca = await areas.addArea(testUser, { areaName: 'CA', parentUuid: usa.metadata.area_id })
+    wa = await areas.addArea(testUser, { areaName: 'WA', parentUuid: usa.metadata.area_id })
     fullOrg = {
       associatedAreaIds: [usa.metadata.area_id],
       excludedAreaIds: [ca.metadata.area_id, wa.metadata.area_id],

--- a/src/model/__tests__/tickValidation.ts
+++ b/src/model/__tests__/tickValidation.ts
@@ -132,10 +132,10 @@ describe('Tick Validation', () => {
     areas = MutableAreaDataSource.getInstance()
     // Add climbs because add/update tick requires type validation
     await areas.addCountry('usa')
-    const newDestination = await areas.addArea(userId, 'California', null, 'usa')
+    const newDestination = await areas.addArea(userId, { areaName: 'California', countryCode: 'usa' })
     if (newDestination == null) fail('Expect new area to be created')
 
-    const routesArea = await areas.addArea(userId, 'Sport & Trad', newDestination.metadata.area_id)
+    const routesArea = await areas.addArea(userId, { areaName: 'Sport & Trad', parentUuid: newDestination.metadata.area_id })
 
     const newIDs = await climbs.addOrUpdateClimbs(userId, routesArea.metadata.area_id, newClimbsToAdd)
 

--- a/src/model/__tests__/ticks.ts
+++ b/src/model/__tests__/ticks.ts
@@ -88,10 +88,10 @@ describe('Ticks', () => {
     areas = MutableAreaDataSource.getInstance()
     // Add climbs because add/update tick requires type validation
     await areas.addCountry('usa')
-    const newDestination = await areas.addArea(userId, 'California', null, 'usa')
+    const newDestination = await areas.addArea(userId, { areaName: 'California', countryCode: 'usa' })
     if (newDestination == null) fail('Expect new area to be created')
 
-    const routesArea = await areas.addArea(userId, 'Sport & Trad', newDestination.metadata.area_id)
+    const routesArea = await areas.addArea(userId, { areaName: 'Sport & Trad', parentUuid: newDestination.metadata.area_id })
 
     const newIDs = await climbs.addOrUpdateClimbs(userId, routesArea.metadata.area_id, newClimbsToAdd)
 

--- a/src/model/__tests__/updateAreas.ts
+++ b/src/model/__tests__/updateAreas.ts
@@ -46,7 +46,7 @@ describe('Areas', () => {
   it('should create a country and 2 subareas', async () => {
     const canada = await areas.addCountry('can')
     // Add 1st area to the country
-    const bc = await areas.addArea(testUser, 'British Columbia', canada.metadata.area_id)
+    const bc = await areas.addArea(testUser, { areaName: 'British Columbia', parentUuid: canada.metadata.area_id })
 
     if (bc == null || canada == null) {
       fail()
@@ -62,7 +62,7 @@ describe('Areas', () => {
     expect(canadaInDb.children[0]).toEqual(bc?._id)
 
     // Add another area to the country
-    const theBug = await areas.addArea(testUser, 'The Bugaboos', canada.metadata.area_id)
+    const theBug = await areas.addArea(testUser, { areaName: 'The Bugaboos', parentUuid: canada.metadata.area_id })
 
     canadaInDb = await areas.findOneAreaByUUID(canada.metadata.area_id)
     expect(canadaInDb.children.length).toEqual(2)
@@ -78,18 +78,19 @@ describe('Areas', () => {
   })
 
   it('should allow adding child areas to empty leaf area', async () => {
-    let parent = await areas.addArea(testUser, 'My house', null, 'can')
+    let parent = await areas.addArea(testUser, { areaName: 'My house', countryCode: 'can' })
     await areas.updateArea(testUser, parent.metadata.area_id, { isLeaf: true, isBoulder: true })
 
     const newClimb = await climbs.addOrUpdateClimbs(testUser, parent.metadata.area_id, [{ name: 'Big Mac' }])
 
     // Try to add a new area when there's already a climb
-    await expect(areas.addArea(testUser, 'Kitchen', parent.metadata.area_id)).rejects.toThrow(/Adding new areas to a leaf or boulder area is not allowed/)
+    await expect(areas.addArea(testUser, { areaName: 'Kitchen', parentUuid: parent.metadata.area_id }))
+      .rejects.toThrow(/Adding new areas to a leaf or boulder area is not allowed/)
 
     // Now remove the climb to see if we can add the area
 
     await climbs.deleteClimbs(testUser, parent.metadata.area_id, [muuid.from(newClimb[0])])
-    await areas.addArea(testUser, 'Kitchen', parent.metadata.area_id)
+    await areas.addArea(testUser, { areaName: 'Kitchen', parentUuid: parent.metadata.area_id })
 
     // Reload the parent
     parent = await areas.findOneAreaByUUID(parent.metadata.area_id)
@@ -102,7 +103,7 @@ describe('Areas', () => {
 
   it('should create an area using only country code (without parent id)', async () => {
     const country = await areas.addCountry('za')
-    const area = await areas.addArea(testUser, 'Table mountain', null, 'zaf')
+    const area = await areas.addArea(testUser, { areaName: 'Table mountain', countryCode: 'zaf' })
 
     const countryInDb = await areas.findOneAreaByUUID(country.metadata.area_id)
     expect(countryInDb.children.length).toEqual(1)
@@ -110,18 +111,18 @@ describe('Areas', () => {
   })
 
   it('should set crag/boulder attribute when adding new areas', async () => {
-    let parent = await areas.addArea(testUser, 'Boulder A', null, 'can', undefined, false, true)
+    let parent = await areas.addArea(testUser, { areaName: 'Boulder A', countryCode: 'can', isBoulder: true, isLeaf: false })
     expect(parent.metadata.isBoulder).toBe(true)
     expect(parent.metadata.leaf).toBe(true)
 
-    parent = await areas.addArea(testUser, 'Sport A', null, 'can', undefined, true, undefined)
+    parent = await areas.addArea(testUser, { areaName: 'Sport A', countryCode: 'can', isLeaf: true })
     expect(parent.metadata.isBoulder).toBe(false)
     expect(parent.metadata.leaf).toBe(true)
   })
 
   it('should update multiple fields', async () => {
     await areas.addCountry('au')
-    const a1 = await areas.addArea(testUser, 'One', null, 'au')
+    const a1 = await areas.addArea(testUser, { areaName: 'One', countryCode: 'au' })
 
     if (a1 == null) {
       fail()
@@ -168,9 +169,9 @@ describe('Areas', () => {
 
   it('should delete a subarea', async () => {
     const usa = await areas.addCountry('usa')
-    const ca = await areas.addArea(testUser, 'CA', usa.metadata.area_id)
-    const or = await areas.addArea(testUser, 'OR', usa.metadata.area_id)
-    const wa = await areas.addArea(testUser, 'WA', usa.metadata.area_id)
+    const ca = await areas.addArea(testUser, { areaName: 'CA', parentUuid: usa.metadata.area_id })
+    const or = await areas.addArea(testUser, { areaName: 'OR', parentUuid: usa.metadata.area_id })
+    const wa = await areas.addArea(testUser, { areaName: 'WA', parentUuid: usa.metadata.area_id })
 
     if (ca == null || or == null || wa == null) {
       fail('Child area is null')
@@ -206,11 +207,11 @@ describe('Areas', () => {
 
   it('should not delete a subarea containing children', async () => {
     const gr = await areas.addCountry('grc')
-    const kali = await areas.addArea(testUser, 'Kalymnos', gr.metadata.area_id)
+    const kali = await areas.addArea(testUser, { areaName: 'Kalymnos', parentUuid: gr.metadata.area_id })
 
     if (kali == null) fail()
 
-    const arhi = await areas.addArea(testUser, 'Arhi', kali.metadata.area_id)
+    const arhi = await areas.addArea(testUser, { areaName: 'Arhi', parentUuid: kali.metadata.area_id })
 
     if (arhi == null) fail()
 
@@ -232,32 +233,32 @@ describe('Areas', () => {
 
   it('should not create duplicate sub-areas', async () => {
     const fr = await areas.addCountry('fra')
-    await areas.addArea(testUser, 'Verdon Gorge', fr.metadata.area_id)
-    await expect(areas.addArea(testUser, 'Verdon Gorge', fr.metadata.area_id))
+    await areas.addArea(testUser, { areaName: 'Verdon Gorge', parentUuid: fr.metadata.area_id })
+    await expect(areas.addArea(testUser, { areaName: 'Verdon Gorge', parentUuid: fr.metadata.area_id }))
       .rejects.toThrowError('This name already exists for some other area in this parent')
   })
 
   it('should fail when adding without a parent country', async () => {
-    await expect(areas.addArea(testUser, 'Peak District ', null, 'GB'))
+    await expect(areas.addArea(testUser, { areaName: 'Peak District ', countryCode: 'GB' }))
       .rejects.toThrowError()
   })
 
   it('should fail when adding with a non-existent parent id', async () => {
     const notInDb = muuid.from('abf6cb8b-8461-45c3-b46b-5997444be867')
-    await expect(areas.addArea(testUser, 'Land\'s End ', notInDb))
+    await expect(areas.addArea(testUser, { areaName: 'Land\'s End ', parentUuid: notInDb }))
       .rejects.toThrowError()
   })
 
   it('should fail when adding with null parents', async () => {
-    await expect(areas.addArea(testUser, 'Land\'s End ', null, '1q1'))
+    await expect(areas.addArea(testUser, { areaName: 'Land\'s End ', countryCode: '1q1' }))
       .rejects.toThrowError()
   })
 
   it('should update areas sorting order', async () => {
     // Setup
     await areas.addCountry('MX')
-    const a1 = await areas.addArea(testUser, 'A1', null, 'MX')
-    const a2 = await areas.addArea(testUser, 'A2', null, 'MX')
+    const a1 = await areas.addArea(testUser, { areaName: 'A1', countryCode: 'MX' })
+    const a2 = await areas.addArea(testUser, { areaName: 'A2', countryCode: 'MX' })
 
     const change1: UpdateSortingOrderType = {
       areaId: a1.metadata.area_id.toUUID().toString(),
@@ -293,13 +294,13 @@ describe('Areas', () => {
 
   it('should update self and childrens pathTokens', async () => {
     await areas.addCountry('JP')
-    const a1 = await areas.addArea(testUser, 'Parent', null, 'JP')
-    const b1 = await areas.addArea(testUser, 'B1', a1.metadata.area_id)
-    const b2 = await areas.addArea(testUser, 'B2', a1.metadata.area_id)
-    const c1 = await areas.addArea(testUser, 'C1', b1.metadata.area_id)
-    const c2 = await areas.addArea(testUser, 'C2', b1.metadata.area_id)
-    const c3 = await areas.addArea(testUser, 'C3', b2.metadata.area_id)
-    const e1 = await areas.addArea(testUser, 'E1', c3.metadata.area_id)
+    const a1 = await areas.addArea(testUser, { areaName: 'Parent', countryCode: 'JP' })
+    const b1 = await areas.addArea(testUser, { areaName: 'B1', parentUuid: a1.metadata.area_id })
+    const b2 = await areas.addArea(testUser, { areaName: 'B2', parentUuid: a1.metadata.area_id })
+    const c1 = await areas.addArea(testUser, { areaName: 'C1', parentUuid: b1.metadata.area_id })
+    const c2 = await areas.addArea(testUser, { areaName: 'C2', parentUuid: b1.metadata.area_id })
+    const c3 = await areas.addArea(testUser, { areaName: 'C3', parentUuid: b2.metadata.area_id })
+    const e1 = await areas.addArea(testUser, { areaName: 'E1', parentUuid: c3.metadata.area_id })
 
     let a1Actual = await areas.findOneAreaByUUID(a1.metadata.area_id)
     expect(a1Actual).toEqual(


### PR DESCRIPTION
This was starting to get a little out of hand, and now the various functions can pass data between themselves only using the props that are relevant to their function

resolves #378