### PR TITLE
add field `wikidata_id` to climbs and areas

### DIFF
--- a/src/db/AreaSchema.ts
+++ b/src/db/AreaSchema.ts
@@ -51,6 +51,7 @@ const MetadataSchema = new Schema<IAreaMetadata>({
   bbox: [{ type: Number, required: false }],
   leftRightIndex: { type: Number, required: false },
   ext_id: { type: String, required: false, index: true },
+  wikidata_id: { type: String, required: false, index: true },
   area_id: {
     type: 'object',
     value: { type: 'Buffer' },

--- a/src/db/AreaTypes.ts
+++ b/src/db/AreaTypes.ts
@@ -149,6 +149,13 @@ export interface IAreaMetadata {
    * this field will record their external relation.
    * */
   ext_id?: string
+
+  /**
+   * Some areas have an identifier on https://www.wikidata.org
+   * This identifier matches the regex `^Q\d+$`
+   * */
+  wikidata_id?: string
+
   /**
    * All external IDs for areas are expressed as UUIDs. As such, when resolving ids at the
    * GQL layer use these values for querying and identification of areas.

--- a/src/db/ClimbSchema.ts
+++ b/src/db/ClimbSchema.ts
@@ -51,6 +51,7 @@ const MetadataSchema = new Schema<IClimbMetadata>({
   left_right_index: { type: Number, required: true, default: -1 },
   mp_id: { type: String, required: false },
   mp_crag_id: { type: String, required: true },
+  wikidata_id: { type: String, required: false },
   areaRef: {
     type: Schema.Types.Mixed,
     value: { type: 'Buffer' },

--- a/src/db/ClimbTypes.ts
+++ b/src/db/ClimbTypes.ts
@@ -127,6 +127,7 @@ export interface DisciplineType {
   /** https://en.wikipedia.org/wiki/Top_rope_climbing */
   tr?: boolean
 }
+
 export interface IClimbMetadata {
   lnglat?: Point
   left_right_index?: number
@@ -137,6 +138,8 @@ export interface IClimbMetadata {
    * for its crag to also be available
    */
   mp_crag_id?: string
+  /** The Wikidata identifier for the route */
+  wikidata_id?: string
   /** the parent Area in which this climb appears */
   areaRef: MUUID
 }

--- a/src/graphql/schema/Area.gql
+++ b/src/graphql/schema/Area.gql
@@ -131,6 +131,7 @@ type AreaMetadata {
 
   "Mountainproject ID (if associated)"
   mp_id: String!
+  wikidata_id: String!
   area_id: ID!
   areaId: ID!
 

--- a/src/graphql/schema/Climb.gql
+++ b/src/graphql/schema/Climb.gql
@@ -96,6 +96,7 @@ type ClimbMetadata {
   leftRightIndex: Int
   "If this climb originated from Mountain Project, this is the ID"
   mp_id: String
+  wikidata_id: String!
   climb_id: ID!
   climbId: ID!
 }


### PR DESCRIPTION
Allow climbs and areas to have Wikidata identifiers.

Various open data projects use these as a common identifier. For example, https://overpass-turbo.eu/s/26jq is a map of all OpenStreetMap POIs tagged with a Wikidata identifier and `sport=climbing`.  https://openclimbing.org uses these identifiers for topophotos.