### PR TITLE
fix: return HTTP 401 for unauthorized mutations

### DIFF
--- a/src/__tests__/bulkImport.test.ts
+++ b/src/__tests__/bulkImport.test.ts
@@ -64,18 +64,18 @@ describe('bulkImportAreas', () => {
     await inMemoryDB.close()
   })
 
-  it('should return 403 if no user', async () => {
+  it('should return 401 if no user', async () => {
     const res = await queryAPI({
       app,
       query,
       operationName: 'bulkImportAreas',
       variables: {input: exampleImportData}
     })
-    expect(res.statusCode).toBe(200)
+    expect(res.statusCode).toBe(401)
     expect(res.body.errors[0].message).toBe('Not Authorised!')
   })
 
-  it('should return 403 if user is not an editor', async () => {
+  it('should return 401 if user is not an editor', async () => {
     const res = await queryAPI({
       app,
       userUuid,
@@ -83,7 +83,7 @@ describe('bulkImportAreas', () => {
       operationName: 'bulkImportAreas',
       variables: {input: exampleImportData}
     })
-    expect(res.statusCode).toBe(200)
+    expect(res.statusCode).toBe(401)
     expect(res.body.errors[0].message).toBe('Not Authorised!')
   })
 

--- a/src/__tests__/organizations.ts
+++ b/src/__tests__/organizations.ts
@@ -170,7 +170,7 @@ describe('organizations API', () => {
         roles: ['editor'],
         app
       })
-      expect(response.statusCode).toBe(200)
+      expect(response.statusCode).toBe(401)
       expect(response.body.data.organization).toBeNull()
       expect(response.body.errors[0].message).toBe('Not Authorised!')
     })

--- a/src/auth/middleware.ts
+++ b/src/auth/middleware.ts
@@ -45,7 +45,9 @@ async function validateTokenAndExtractUser (req: Request): Promise<CustomContext
       }
     } catch (e) {
       logger.error(`Can't verify JWT token ${e.toString() as string}`)
-      throw new Error("Unauthorized. Can't verify JWT token")
+      // Return empty user instead of throwing - allows public queries to work
+      // Mutations will be blocked by graphql-shield permissions
+      return { user: EMTPY_USER }
     }
   }
 

--- a/src/auth/permissions.ts
+++ b/src/auth/permissions.ts
@@ -1,3 +1,4 @@
+import { GraphQLError } from 'graphql'
 import { allow, and, or, shield } from 'graphql-shield'
 import { isEditor, isMediaOwner, isOwner, isUserAdmin, isValidEmail } from './rules.js'
 
@@ -24,7 +25,13 @@ const permissions = shield({
 },
 {
   allowExternalErrors: true,
-  fallbackRule: allow
+  fallbackRule: allow,
+  fallbackError: new GraphQLError('Not Authorised!', {
+    extensions: {
+      code: 'FORBIDDEN',
+      http: { status: 401 }
+    }
+  })
 })
 
 export default permissions


### PR DESCRIPTION
Return HTTP 401 instead of 200 for unauthorized mutations. Handle expired tokens gracefully.